### PR TITLE
Migrate to Provider for state management

### DIFF
--- a/lib/controller/home_controller.dart
+++ b/lib/controller/home_controller.dart
@@ -6,9 +6,6 @@ import 'package:hidroly/model/water_button.dart';
 class HomeController {
   User? user;
   List<WaterButton>? customCups = [];
-  
-  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
-  final TextEditingController customCupAmountController = TextEditingController();
 
   Future<void> loadUser() async {
     user = await DatabaseHelper.instance.getUser(1);
@@ -23,17 +20,16 @@ class HomeController {
     customCups = await DatabaseHelper.instance.getAllCustomCups();
   }
 
-  Future<void> onSubmitCustomCup(context) async {
-    if(formKey.currentState!.validate()) {
-      int customCupAmount = int.parse(customCupAmountController.text);
+  Future<bool> createCustomCup(String amountText) async {
+    int? customCupAmount = int.tryParse(amountText);
 
-      await DatabaseHelper.instance.createCustomCup(
-        WaterButton(amount: customCupAmount),
-      );
+    if(customCupAmount == null) return false;
 
-      await loadCustomCups();
-      customCupAmountController.clear();
-      Navigator.pop(context);
-    }
+    await DatabaseHelper.instance.createCustomCup(
+      WaterButton(amount: customCupAmount),
+    );
+
+    await loadCustomCups();
+    return true;
   }
 }

--- a/lib/controller/home_controller.dart
+++ b/lib/controller/home_controller.dart
@@ -1,20 +1,8 @@
-import 'package:flutter/widgets.dart';
 import 'package:hidroly/database/database_helper.dart';
-import 'package:hidroly/model/User.dart';
 import 'package:hidroly/model/water_button.dart';
 
 class HomeController {
-  User? user;
   List<WaterButton>? customCups = [];
-
-  Future<void> loadUser() async {
-    user = await DatabaseHelper.instance.getUser(1);
-  }
-  
-  Future<void> updateUser(User updatedUser) async {
-    await DatabaseHelper.instance.updateUser(updatedUser);
-    await loadUser();
-  }
 
   Future<void> loadCustomCups() async {
     customCups = await DatabaseHelper.instance.getAllCustomCups();

--- a/lib/controller/setup_controller.dart
+++ b/lib/controller/setup_controller.dart
@@ -1,5 +1,5 @@
 import 'package:hidroly/database/database_helper.dart';
-import 'package:hidroly/model/User.dart';
+import 'package:hidroly/model/user.dart';
 import 'package:hidroly/utils/calculate_dailygoal.dart';
 
 class SetupController {

--- a/lib/controller/setup_controller.dart
+++ b/lib/controller/setup_controller.dart
@@ -1,29 +1,16 @@
-import 'package:flutter/material.dart';
 import 'package:hidroly/database/database_helper.dart';
 import 'package:hidroly/model/User.dart';
-import 'package:hidroly/pages/home_page.dart';
 import 'package:hidroly/utils/calculate_dailygoal.dart';
 
 class SetupController {
-  final TextEditingController ageController = TextEditingController();
-  final TextEditingController weightController = TextEditingController();
-  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+  Future<bool> save(String ageText, String weightText) async {
+    int? age = int.tryParse(ageText);
+    int? weight = int.tryParse(weightText);
 
-  void onSubmit(context) async {
-    if(formKey.currentState!.validate()) {
-      int age = int.parse(ageController.text);
-      int weight = int.parse(weightController.text);
+    if(age == null || weight == null) return false;
 
-      int dailyGoal = CalculateDailyGoal().calculate(age, weight);
-      await DatabaseHelper.instance.createUser(User(id: 1, dailyGoal: dailyGoal, currentAmount: 0));
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (BuildContext context) => const HomePage())
-      );
-    }
-  }
-
-  void dispose() {
-    ageController.dispose();
-    weightController.dispose();
+    int dailyGoal = CalculateDailyGoal().calculate(age, weight);
+    await DatabaseHelper.instance.createUser(User(id: 1, dailyGoal: dailyGoal, currentAmount: 0));
+    return true;
   }
 }

--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -1,4 +1,4 @@
-import 'package:hidroly/model/User.dart';
+import 'package:hidroly/model/user.dart';
 import 'package:hidroly/model/water_button.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,12 @@ import 'package:hidroly/theme/app_theme.dart';
 import 'package:provider/provider.dart';
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  runApp(const MainApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (context) => UserProvider(),
+      child: const MainApp(),
+    )
+  );
 }
 
 class MainApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ class MainApp extends StatelessWidget {
       theme: AppTheme.darkTheme,
       home: ChangeNotifierProvider(
         create: (context) => UserProvider(),
-        child: const HomePage(),
+        builder: (context, child) => const HomePage(),
       )
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/pages/home_page.dart';
+import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_theme.dart';
 import 'package:provider/provider.dart';
 
 void main() async {
   runApp(
-    ChangeNotifierProvider(
-      create: (context) => UserProvider(),
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => UserProvider()),
+        ChangeNotifierProvider(create: (context) => CustomCupsProvider()),
+      ],
       child: const MainApp(),
     )
   );
@@ -20,10 +24,7 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: AppTheme.darkTheme,
-      home: ChangeNotifierProvider(
-        create: (context) => UserProvider(),
-        builder: (context, child) => const HomePage(),
-      )
+      home:const HomePage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: AppTheme.darkTheme,
-      home:const HomePage(),
+      home: const HomePage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/pages/home_page.dart';
+import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_theme.dart';
+import 'package:provider/provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -14,7 +16,10 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: AppTheme.darkTheme,
-      home: HomePage(),
+      home: ChangeNotifierProvider(
+        create: (context) => UserProvider(),
+        child: const HomePage(),
+      )
     );
   }
 }

--- a/lib/model/User.dart
+++ b/lib/model/User.dart
@@ -17,4 +17,12 @@ class User {
   String toString() {
     return 'User{id: $id, dailyGoal: $dailyGoal, currentAmount: $currentAmount}';
   }
+
+  User copyWith({int? id, int? dailyGoal, int? currentAmount}) {
+    return User(
+      id: id ?? this.id,
+      dailyGoal: dailyGoal ?? this.dailyGoal,
+      currentAmount: currentAmount ?? this.currentAmount,
+    );
+  }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -45,7 +45,7 @@ class _HomePageState extends State<HomePage> {
               spacing: 50,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                WaterProgressCircle(user: homeController.user!,),
+                WaterProgressCircle(),
                 WaterActionButtons(
                   homeController: homeController,
                   customCupAmountController: customCupAmountController,

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -30,7 +30,7 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    if(context.watch<UserProvider>().userStatus == UserStatus.loading) {
+    if(context.watch<UserProvider>().user == null) {
       return Scaffold(
         body: Center(child: CircularProgressIndicator(),),
       );

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -27,6 +27,12 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
+  void dispose() {
+    customCupAmountController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     if(context.watch<UserProvider>().user == null) {
       return Scaffold(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/controller/home_controller.dart';
 import 'package:hidroly/pages/setup_page.dart';
+import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
 import 'package:hidroly/widgets/home/water_progress_circle.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -28,7 +30,7 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    if(homeController.user == null) {
+    if(context.watch<UserProvider>().userStatus == UserStatus.loading) {
       return Scaffold(
         body: Center(child: CircularProgressIndicator(),),
       );
@@ -82,16 +84,16 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _loadUser() async {
-    await homeController.loadUser();
-    if(homeController.user == null) {
+    final userProvider = context.read<UserProvider>();
+
+    await userProvider.loadUser();
+    if(userProvider.user == null && mounted) {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => SetupPage()),
       );
       return;
     }
-
-    setState(() {});
   }
 
   void _loadCustomCups() async {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/controller/home_controller.dart';
 import 'package:hidroly/pages/setup_page.dart';
+import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
@@ -18,8 +18,6 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   final TextEditingController customCupAmountController = TextEditingController();
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
-
-  final HomeController homeController = HomeController();
 
   @override
   void initState() {
@@ -49,11 +47,8 @@ class _HomePageState extends State<HomePage> {
               children: [
                 WaterProgressCircle(),
                 WaterActionButtons(
-                  homeController: homeController,
                   customCupAmountController: customCupAmountController,
                   formKey: formKey,
-                  customCups: homeController.customCups ?? [],
-                  onUpdate: () => setState(() {}),
                 )
               ],
             ),
@@ -97,7 +92,6 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _loadCustomCups() async {
-    await homeController.loadCustomCups();
-    setState(() {});
+    await context.read<CustomCupsProvider>().loadCustomCups();
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -14,7 +14,10 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  HomeController homeController = HomeController();
+  final TextEditingController customCupAmountController = TextEditingController();
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+  final HomeController homeController = HomeController();
 
   @override
   void initState() {
@@ -45,6 +48,8 @@ class _HomePageState extends State<HomePage> {
                 WaterProgressCircle(user: homeController.user!,),
                 WaterActionButtons(
                   homeController: homeController,
+                  customCupAmountController: customCupAmountController,
+                  formKey: formKey,
                   customCups: homeController.customCups ?? [],
                   onUpdate: () => setState(() {}),
                 )

--- a/lib/pages/setup_page.dart
+++ b/lib/pages/setup_page.dart
@@ -16,7 +16,7 @@ class _SetupPageState extends State<SetupPage> {
   final TextEditingController weightController = TextEditingController();
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
-  SetupController setupController = SetupController();
+  final SetupController setupController = SetupController();
 
   @override
   void dispose() {

--- a/lib/pages/setup_page.dart
+++ b/lib/pages/setup_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/controller/setup_controller.dart';
+import 'package:hidroly/pages/home_page.dart';
 import 'package:hidroly/widgets/setup/setup_header.dart';
 import 'package:hidroly/widgets/setup/setup_interactable.dart';
 
@@ -11,7 +12,18 @@ class SetupPage extends StatefulWidget {
 }
 
 class _SetupPageState extends State<SetupPage> {
+  final TextEditingController ageController = TextEditingController();
+  final TextEditingController weightController = TextEditingController();
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
   SetupController setupController = SetupController();
+
+  @override
+  void dispose() {
+    ageController.dispose();
+    weightController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -22,11 +34,14 @@ class _SetupPageState extends State<SetupPage> {
           child: Padding(
             padding: const EdgeInsets.only(left: 30.0, right: 30.0, bottom: 64),
             child: Form(
-              key: setupController.formKey,
+              key: formKey,
               child: Column(
                 children: [
                   SetupHeader(),
-                  SetupInteractable(setupController: setupController ,),
+                  SetupInteractable(
+                    ageController: ageController,
+                    weightController: weightController,
+                  ),
                   Text(
                     'Your data is stored on your device.',
                     style: Theme.of(context).textTheme.bodySmall,
@@ -38,7 +53,21 @@ class _SetupPageState extends State<SetupPage> {
         ),
       ),
       floatingActionButton: IconButton.filled(
-        onPressed: () => setupController.onSubmit(context),
+        onPressed: () async {
+          if(!formKey.currentState!.validate()) return;
+
+          bool created = await setupController.save(
+            ageController.text,
+            weightController.text,
+          );
+
+          if(created && context.mounted) {
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (context) => HomePage()),
+            );
+            return;
+          }
+        },
         icon: Icon(
           Icons.arrow_forward,
         ),

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -1,11 +1,14 @@
+import 'package:flutter/material.dart';
 import 'package:hidroly/database/database_helper.dart';
 import 'package:hidroly/model/water_button.dart';
 
-class HomeController {
-  List<WaterButton>? customCups = [];
+class CustomCupsProvider extends ChangeNotifier {
+  List<WaterButton> _customCups = [];
+  List<WaterButton> get customCups => _customCups;
 
   Future<void> loadCustomCups() async {
-    customCups = await DatabaseHelper.instance.getAllCustomCups();
+    _customCups = await DatabaseHelper.instance.getAllCustomCups();
+    notifyListeners();
   }
 
   Future<bool> createCustomCup(String amountText) async {

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -22,6 +22,5 @@ class UserProvider extends ChangeNotifier {
     );
 
     await updateUser(updatedUser);
-    notifyListeners();
   }
 }

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -25,6 +25,15 @@ class UserProvider extends ChangeNotifier {
     await DatabaseHelper.instance.updateUser(updatedUser);
     await loadUser();
   }
+
+  Future<void> addWater(int amount) async {
+    User updatedUser = _user!.copyWith(
+      currentAmount: _user!.currentAmount + amount,
+    );
+
+    await updateUser(updatedUser);
+    notifyListeners();
+  }
 }
 
 enum UserStatus {loading, loaded, empty}

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+import 'package:hidroly/database/database_helper.dart';
+import 'package:hidroly/model/user.dart';
+
+class UserProvider extends ChangeNotifier {
+  User? user;
+
+  Future<void> loadUser() async {
+    user = await DatabaseHelper.instance.getUser(1);
+    notifyListeners();
+  }
+  
+  Future<void> updateUser(User updatedUser) async {
+    await DatabaseHelper.instance.updateUser(updatedUser);
+    await loadUser();
+  }
+}

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -3,10 +3,21 @@ import 'package:hidroly/database/database_helper.dart';
 import 'package:hidroly/model/user.dart';
 
 class UserProvider extends ChangeNotifier {
-  User? user;
+  User? _user;
+  User? get user => _user;
+
+  UserStatus _userStatus = UserStatus.loading;
+  UserStatus get userStatus => _userStatus;
 
   Future<void> loadUser() async {
-    user = await DatabaseHelper.instance.getUser(1);
+    _user = await DatabaseHelper.instance.getUser(1);
+
+    if(user == null) {
+      _userStatus = UserStatus.empty;
+    } else {
+      _userStatus = UserStatus.loaded;
+    }
+
     notifyListeners();
   }
   
@@ -15,3 +26,5 @@ class UserProvider extends ChangeNotifier {
     await loadUser();
   }
 }
+
+enum UserStatus {loading, loaded, empty}

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -6,18 +6,8 @@ class UserProvider extends ChangeNotifier {
   User? _user;
   User? get user => _user;
 
-  UserStatus _userStatus = UserStatus.loading;
-  UserStatus get userStatus => _userStatus;
-
   Future<void> loadUser() async {
     _user = await DatabaseHelper.instance.getUser(1);
-
-    if(user == null) {
-      _userStatus = UserStatus.empty;
-    } else {
-      _userStatus = UserStatus.loaded;
-    }
-
     notifyListeners();
   }
   
@@ -35,5 +25,3 @@ class UserProvider extends ChangeNotifier {
     notifyListeners();
   }
 }
-
-enum UserStatus {loading, loaded, empty}

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -6,7 +6,10 @@ import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';
 
 class WaterActionButtons extends StatelessWidget {
-  HomeController homeController;
+  final TextEditingController customCupAmountController;
+  final GlobalKey<FormState> formKey;
+
+  final HomeController homeController;
   final VoidCallback onUpdate;
 
   List<WaterButton> get defaultButtons => [
@@ -27,6 +30,8 @@ class WaterActionButtons extends StatelessWidget {
   WaterActionButtons({
     super.key,
     required this.homeController,
+    required this.customCupAmountController,
+    required this.formKey,
     required this.customCups,
     required this.onUpdate,
   });
@@ -85,10 +90,10 @@ class WaterActionButtons extends StatelessWidget {
           style: Theme.of(context).textTheme.titleLarge,
         ),
         content: Form(
-          key: homeController.formKey,
+          key: formKey,
           child: FormNumberInputField(
             label: 'Amount', 
-            controller: homeController.customCupAmountController, 
+            controller: customCupAmountController, 
             validator: (value) {
               int? amount = int.tryParse(value ?? '');
               if(amount == null || amount <= 0) return 'Invalid amount.';
@@ -99,8 +104,13 @@ class WaterActionButtons extends StatelessWidget {
         actions: [
           TextButton(
             onPressed: () async {
-              await homeController.onSubmitCustomCup(context);
-              onUpdate();
+              bool created = await homeController.createCustomCup(
+                customCupAmountController.text
+              );
+
+              if(created) {
+                onUpdate();
+              }
             }, 
             child: Text(
               'Add',

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -108,7 +108,8 @@ class WaterActionButtons extends StatelessWidget {
                 customCupAmountController.text
               );
 
-              if(created) {
+              if(created && context.mounted) {
+                Navigator.of(context).pop();
                 onUpdate();
               }
             }, 

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/controller/home_controller.dart';
-import 'package:hidroly/model/user.dart';
 import 'package:hidroly/model/water_button.dart';
+import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';
+import 'package:provider/provider.dart';
 
 class WaterActionButtons extends StatelessWidget {
   final TextEditingController customCupAmountController;
@@ -54,7 +55,7 @@ class WaterActionButtons extends StatelessWidget {
                 return;
               }
 
-              await _updateWaterIntake(button);
+              await context.read<UserProvider>().addWater(button.amount);
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: Color(0xff31333A),
@@ -130,16 +131,5 @@ class WaterActionButtons extends StatelessWidget {
         backgroundColor: Theme.of(context).colorScheme.surface,
       )
     );
-  }
-
-  Future<void> _updateWaterIntake(WaterButton button) async {
-    User currentUser = homeController.user!;
-    User updatedUser = User(
-      id: currentUser.id, 
-      dailyGoal: currentUser.dailyGoal, 
-      currentAmount: currentUser.currentAmount + button.amount
-    );
-    await homeController.updateUser(updatedUser);
-    onUpdate();
   }
 }

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/controller/home_controller.dart';
 import 'package:hidroly/model/water_button.dart';
+import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/user_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';
@@ -10,35 +10,26 @@ class WaterActionButtons extends StatelessWidget {
   final TextEditingController customCupAmountController;
   final GlobalKey<FormState> formKey;
 
-  final HomeController homeController;
-  final VoidCallback onUpdate;
-
-  List<WaterButton> get defaultButtons => [
-    WaterButton(amount: 250),
-    WaterButton(amount: 350)
-  ];
-
-  List<WaterButton> customCups;
-
-  WaterButton get customAddButton => WaterButton(amount: 0, isCustomOption: true);
-
-  List<WaterButton> get allButtons => [
-    ...defaultButtons,
-    ...customCups,
-    customAddButton,
-  ];
+  final _defaultButtons = [WaterButton(amount: 250), WaterButton(amount: 350)];
+  final _addCustomCupButton = WaterButton(amount: 0, isCustomOption: true);
 
   WaterActionButtons({
     super.key,
-    required this.homeController,
     required this.customCupAmountController,
     required this.formKey,
-    required this.customCups,
-    required this.onUpdate,
   });
 
   @override
   Widget build(BuildContext context) {
+    final List<WaterButton> customCups = 
+      context.watch<CustomCupsProvider>().customCups;
+    
+    List<WaterButton> allButtons = [
+      ..._defaultButtons,
+      ...customCups,
+      _addCustomCupButton,
+    ];
+
     return Container(
       height: 45,
       margin: EdgeInsets.only(left: 15, right: 15),
@@ -107,14 +98,13 @@ class WaterActionButtons extends StatelessWidget {
             onPressed: () async {
               if(!formKey.currentState!.validate()) return;
 
-              bool created = await homeController.createCustomCup(
+              bool created = await context.read<CustomCupsProvider>().createCustomCup(
                 customCupAmountController.text
               );
 
               if(created && context.mounted) {
                 Navigator.of(context).pop();
                 customCupAmountController.clear();
-                onUpdate();
               }
             }, 
             child: Text(

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/controller/home_controller.dart';
-import 'package:hidroly/model/User.dart';
+import 'package:hidroly/model/user.dart';
 import 'package:hidroly/model/water_button.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -112,6 +112,7 @@ class WaterActionButtons extends StatelessWidget {
 
               if(created && context.mounted) {
                 Navigator.of(context).pop();
+                customCupAmountController.clear();
                 onUpdate();
               }
             }, 

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -104,6 +104,8 @@ class WaterActionButtons extends StatelessWidget {
         actions: [
           TextButton(
             onPressed: () async {
+              if(!formKey.currentState!.validate()) return;
+
               bool created = await homeController.createCustomCup(
                 customCupAmountController.text
               );

--- a/lib/widgets/home/water_progress_circle.dart
+++ b/lib/widgets/home/water_progress_circle.dart
@@ -1,43 +1,53 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/model/user.dart';
+import 'package:hidroly/provider/user_provider.dart';
+import 'package:provider/provider.dart';
 
 class WaterProgressCircle extends StatelessWidget {
-  User user;
-
-  WaterProgressCircle({
+  const WaterProgressCircle({
     super.key,
-    required this.user,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: AlignmentGeometry.xy(0, 0),
-      children: [
-        SizedBox(
-            width: 280,
-            height: 280,
-            child: CircularProgressIndicator(
-              value: (user.currentAmount / user.dailyGoal).clamp(0, 1),
-              backgroundColor: Theme.of(context).colorScheme.onSurface,
-              strokeWidth: 20,
-              strokeCap: StrokeCap.round,
-              color: Theme.of(context).primaryColor,
-            ),
-        ),
-        Column(
+    return Consumer<UserProvider>(
+      builder: (context, provider, child) {
+        final user = provider.user;
+
+        if(user == null) {
+          return const CircularProgressIndicator();
+        }
+
+        final double progress = (user.currentAmount / user.dailyGoal).clamp(0, 1);
+
+        return Stack(
+          alignment: AlignmentGeometry.xy(0, 0),
           children: [
-            Text(
-              '${user.currentAmount}ml',
-              style: Theme.of(context).textTheme.headlineLarge,
+            SizedBox(
+                width: 280,
+                height: 280,
+                child: CircularProgressIndicator(
+                  value: progress,
+                  backgroundColor: Theme.of(context).colorScheme.onSurface,
+                  strokeWidth: 20,
+                  strokeCap: StrokeCap.round,
+                  color: Theme.of(context).primaryColor,
+                ),
             ),
-            Text(
-              'of ${user.dailyGoal}ml',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-          ],
-        )
-      ]
+            Column(
+              children: [
+                Text(
+                  '${user.currentAmount}ml',
+                  style: Theme.of(context).textTheme.headlineLarge,
+                ),
+                Text(
+                  'of ${user.dailyGoal}ml',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ],
+            )
+          ]
+        );
+      }
     );
   }
 }

--- a/lib/widgets/home/water_progress_circle.dart
+++ b/lib/widgets/home/water_progress_circle.dart
@@ -13,6 +13,7 @@ class WaterProgressCircle extends StatelessWidget {
       builder: (context, provider, child) {
         final user = provider.user;
 
+        // TODO: This should be better handled.
         if(user == null) {
           return const CircularProgressIndicator();
         }

--- a/lib/widgets/home/water_progress_circle.dart
+++ b/lib/widgets/home/water_progress_circle.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/model/User.dart';
+import 'package:hidroly/model/user.dart';
 
 class WaterProgressCircle extends StatelessWidget {
   User user;

--- a/lib/widgets/input/form_number_input_field.dart
+++ b/lib/widgets/input/form_number_input_field.dart
@@ -4,9 +4,9 @@ import 'package:flutter/services.dart';
 class FormNumberInputField extends StatelessWidget {
   final String label;
   final TextEditingController controller;
-  String? Function(String?)? validator;
+  final String? Function(String?)? validator;
 
-  FormNumberInputField({
+  const FormNumberInputField({
     super.key,
     required this.label,
     required this.controller,

--- a/lib/widgets/setup/setup_interactable.dart
+++ b/lib/widgets/setup/setup_interactable.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/controller/setup_controller.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';
 
 class SetupInteractable extends StatelessWidget {
-  final SetupController setupController;
+  final TextEditingController ageController;
+  final TextEditingController weightController;
 
   const SetupInteractable({
     super.key,
-    required this.setupController,
+    required this.ageController,
+    required this.weightController,
   });
 
   @override
@@ -18,7 +19,7 @@ class SetupInteractable extends StatelessWidget {
         spacing: 10,
         children: [
           FormNumberInputField(
-            controller: setupController.ageController, 
+            controller: ageController, 
             label: 'Your age',
             validator: (value) {
               final age = int.tryParse(value ?? '');
@@ -27,7 +28,7 @@ class SetupInteractable extends StatelessWidget {
             },
           ),
           FormNumberInputField(
-            controller: setupController.weightController, 
+            controller: weightController, 
             label: 'Your weight',
             validator: (value) {
               final weight = int.tryParse(value ?? '');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -155,6 +155,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: "direct main"
     description:
@@ -195,6 +203,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_svg: ^2.2.0
   path: ^1.9.1
+  provider: ^6.1.5
   sqflite: ^2.4.2
 
 dev_dependencies:


### PR DESCRIPTION
This PR introduces Provider as the state manager for the project.

Changes:
- Added UserProvider to manage user-related state (hydration goal, current amount, etc).
- Added CustomCupsProvider to handle custom water cup sizes.
- Wrapped the app with MultiProvider in main.dart to provide both states globally.
- Updated WaterActionButtons and other widgets to consume data via context.watch and context.read.

Also made some miscellaneous changes that helped lay the foundation for the migration:
- Controllers were moved from providers/controllers to their respective widgets.
- SetupController is now very simple, doing what it should do: interact with services, not the UI.

Using Provider is the first step towards improving the project's scalability, making it easier to implement features like history, removing entries and more. Also, it simplifies reactivity a lot, and decreases code coupling.