### PR TITLE
 Implement Day Selection Feature

### DIFF
--- a/lib/data/datasource/day_local_datasource.dart
+++ b/lib/data/datasource/day_local_datasource.dart
@@ -5,5 +5,5 @@ abstract class DayLocalDataSource {
   Future<void> update(Day day);
   Future<Day?> findFirst();
   Future<Day?> findLatest();
-  Future<Day?> findByDate(DateTime date);
+  Future<Day?> findByDate(String start, String end);
 }

--- a/lib/data/datasource/day_local_datasource.dart
+++ b/lib/data/datasource/day_local_datasource.dart
@@ -3,6 +3,7 @@ import 'package:hidroly/data/model/day.dart';
 abstract class DayLocalDataSource {
   Future<void> create(Day day);
   Future<void> update(Day day);
+  Future<Day?> findFirst();
   Future<Day?> findLatest();
   Future<Day?> findByDate(DateTime date);
 }

--- a/lib/data/datasource/day_local_datasource_impl.dart
+++ b/lib/data/datasource/day_local_datasource_impl.dart
@@ -31,6 +31,28 @@ class DayLocalDataSourceImpl implements DayLocalDataSource {
   }
 
   @override
+  Future<Day?> findFirst() async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, Object?>> daysList = await db.query(
+      DBConstants.daysTable, 
+      orderBy: 'date ASC',
+      limit: 1
+    );
+
+    if(daysList.isEmpty) return null;
+    Map<String, Object?> dayMap = daysList.first;
+
+    Day day = Day(
+      id: dayMap['id'] as int,
+      dailyGoal: dayMap['dailyGoal'] as int,
+      currentAmount: dayMap['currentAmount'] as int,
+      date: DateTime.parse(dayMap['date'] as String),
+    );
+
+    return day;
+  }
+
+  @override
   Future<Day?> findLatest() async {
     final db = await _databaseHelper.database;
     final List<Map<String, Object?>> daysList = await db.query(

--- a/lib/data/datasource/day_local_datasource_impl.dart
+++ b/lib/data/datasource/day_local_datasource_impl.dart
@@ -87,6 +87,7 @@ class DayLocalDataSourceImpl implements DayLocalDataSource {
       limit: 1,
     );
 
+    if(dayList.isEmpty) return null;
     Map<String, Object?> dayMap = dayList.first;
     
     return Day(

--- a/lib/data/datasource/day_local_datasource_impl.dart
+++ b/lib/data/datasource/day_local_datasource_impl.dart
@@ -75,14 +75,12 @@ class DayLocalDataSourceImpl implements DayLocalDataSource {
   }
   
   @override
-  Future<Day?> findByDate(DateTime date) async {
-    final iso = date.toIso8601String();
-
+  Future<Day?> findByDate(String start, String end) async {
     final db = await _databaseHelper.database;
     final List<Map<String, Object?>> dayList = await db.query(
       DBConstants.daysTable,
-      where: 'date = ?',
-      whereArgs: [iso],
+      where: 'date >= ? AND date < ?',
+      whereArgs: [start, end],
       orderBy: 'date DESC',
       limit: 1,
     );
@@ -92,8 +90,8 @@ class DayLocalDataSourceImpl implements DayLocalDataSource {
     
     return Day(
       id: dayMap['id'] as int,
-      dailyGoal: dayMap['daily_goal'] as int,
-      currentAmount: dayMap['current_amount'] as int,
+      dailyGoal: dayMap['dailyGoal'] as int,
+      currentAmount: dayMap['currentAmount'] as int,
       date: DateTime.parse(dayMap['date'] as String),
     );
   }

--- a/lib/data/datasource/day_local_datasource_impl.dart
+++ b/lib/data/datasource/day_local_datasource_impl.dart
@@ -76,11 +76,13 @@ class DayLocalDataSourceImpl implements DayLocalDataSource {
   
   @override
   Future<Day?> findByDate(DateTime date) async {
+    final iso = date.toIso8601String();
+
     final db = await _databaseHelper.database;
     final List<Map<String, Object?>> dayList = await db.query(
       DBConstants.daysTable,
       where: 'date = ?',
-      whereArgs: [date],
+      whereArgs: [iso],
       orderBy: 'date DESC',
       limit: 1,
     );

--- a/lib/data/model/day.dart
+++ b/lib/data/model/day.dart
@@ -23,7 +23,7 @@ class Day {
 
   @override
   String toString() {
-    return 'Day{id: $id, dailyGoal: $dailyGoal, currentAmount: $currentAmount}';
+    return 'Day{id: $id, dailyGoal: $dailyGoal, currentAmount: $currentAmount, date: $date}';
   }
 
   Day copyWith({int? id, int? dailyGoal, int? currentAmount, DateTime? date}) {

--- a/lib/data/repository/day_repository.dart
+++ b/lib/data/repository/day_repository.dart
@@ -8,6 +8,8 @@ class DayRepository {
 
   Future<void> create(Day user) async => await _userLocalDataSourceImpl.create(user);
 
+  Future<Day?> findFirst() async => await _userLocalDataSourceImpl.findFirst();
+
   Future<Day?> findLatest() async => await _userLocalDataSourceImpl.findLatest();
 
   Future<Day?> findByDate(DateTime date) async => await _userLocalDataSourceImpl.findByDate(date);

--- a/lib/data/repository/day_repository.dart
+++ b/lib/data/repository/day_repository.dart
@@ -12,7 +12,12 @@ class DayRepository {
 
   Future<Day?> findLatest() async => await _userLocalDataSourceImpl.findLatest();
 
-  Future<Day?> findByDate(DateTime date) async => await _userLocalDataSourceImpl.findByDate(date);
+  Future<Day?> findByDate(DateTime date) async {
+    final startUtc = date.toUtc();
+    final endUtc = startUtc.add(Duration(days: 1));
+
+    return await _userLocalDataSourceImpl.findByDate(startUtc.toIso8601String(), endUtc.toIso8601String());
+  }
   
   Future<void> update(Day updatedUser) async => await _userLocalDataSourceImpl.update(updatedUser);
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -84,12 +84,27 @@ class _HomePageState extends State<HomePage> {
 
           if(!mounted || firstDate == null || latestDate == null) return;
 
-          showDatePicker(
+          final DateTime? pickedDate = await showDatePicker(
             context: context,
             initialDate: latestDate.date.toLocal(),
-            firstDate: firstDate.date.toLocal(), 
+            firstDate: firstDate.date.toLocal(),
             lastDate: latestDate.date.toLocal(),
           );
+
+          if(pickedDate == null) return;
+
+          final loadedDay = await provider.findByDate(pickedDate);
+          if(loadedDay == null && mounted) {
+            ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(
+                content: Text('Day not found!'),
+              )
+            );
+            return;
+          }
+
+          provider.day = loadedDay;
+          _loadDailyHistory(currentDay: provider.day);
         },
         style: TextButton.styleFrom(
           padding: EdgeInsets.zero,
@@ -171,8 +186,8 @@ class _HomePageState extends State<HomePage> {
     await context.read<CustomCupsProvider>().loadCustomCups();
   }
 
-  Future<void> _loadDailyHistory() async {
-    final currentDay = context.read<DayProvider>().day;
+  Future<void> _loadDailyHistory({Day? currentDay}) async {
+    currentDay ??= context.read<DayProvider>().day;
 
     // TODO: Maybe return to the setup page?
     if(currentDay == null) return;

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -6,11 +6,11 @@ import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/theme/app_theme.dart';
+import 'package:hidroly/utils/app_date_utils.dart';
 import 'package:hidroly/widgets/home/daily_history_bottom_sheet.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
 import 'package:hidroly/widgets/home/water_progress_circle.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
@@ -97,7 +97,7 @@ class _HomePageState extends State<HomePage> {
           if(loadedDay == null && mounted) {
             ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(
-                content: Text('Day not found!'),
+                content: Text('Day not found'),
               )
             );
             return;
@@ -113,7 +113,7 @@ class _HomePageState extends State<HomePage> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              DateFormat.yMMMMd().format(currentDay.date.toLocal()),
+              AppDateUtils.formatDayTitle(currentDay.date.toLocal()),
               style: AppTheme.darkTheme.appBarTheme.titleTextStyle,
             ),
             Icon(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -49,7 +49,7 @@ class _HomePageState extends State<HomePage> {
     }
 
     return Scaffold(
-      appBar: appBar(currentDay, dayId),
+      appBar: appBar(dayId),
       bottomNavigationBar: HomeBottomNav(),
       body: Center(
         child: SingleChildScrollView(
@@ -73,20 +73,21 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  AppBar appBar(Day currentDay, int dayId) {
+  AppBar appBar(int dayId) {
     return AppBar(
       title: TextButton(
         onPressed: () async {
           final provider = context.read<DayProvider>();
           final firstDate = await provider.findFirst();
+          final latestDate = await provider.findLatest();
 
-          if(!mounted || firstDate == null) return;
+          if(!mounted || firstDate == null || latestDate == null) return;
 
           showDatePicker(
             context: context,
-            initialDate: currentDay.date.toLocal(),
+            initialDate: latestDate.date.toLocal(),
             firstDate: firstDate.date.toLocal(), 
-            lastDate: currentDay.date.toLocal(),
+            lastDate: latestDate.date.toLocal(),
           );
         },
         style: TextButton.styleFrom(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -10,6 +10,7 @@ import 'package:hidroly/widgets/home/daily_history_bottom_sheet.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
 import 'package:hidroly/widgets/home/water_progress_circle.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
@@ -49,7 +50,7 @@ class _HomePageState extends State<HomePage> {
     }
 
     return Scaffold(
-      appBar: appBar(dayId),
+      appBar: appBar(currentDay, dayId),
       bottomNavigationBar: HomeBottomNav(),
       body: Center(
         child: SingleChildScrollView(
@@ -73,7 +74,7 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  AppBar appBar(int dayId) {
+  AppBar appBar(Day currentDay, int dayId) {
     return AppBar(
       title: TextButton(
         onPressed: () async {
@@ -97,7 +98,7 @@ class _HomePageState extends State<HomePage> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              'Today',
+              DateFormat.yMMMMd().format(currentDay.date.toLocal()),
               style: AppTheme.darkTheme.appBarTheme.titleTextStyle,
             ),
             Icon(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -39,17 +39,17 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    final Day? day = context.watch<DayProvider>().day;
-    final int? dayId = day?.id;
+    final Day? currentDay = context.watch<DayProvider>().day;
+    final int? dayId = currentDay?.id;
 
-    if(day == null || dayId == null) {
+    if(currentDay == null || dayId == null) {
       return Scaffold(
         body: Center(child: CircularProgressIndicator(),),
       );
     }
 
     return Scaffold(
-      appBar: appBar(dayId),
+      appBar: appBar(currentDay, dayId),
       bottomNavigationBar: HomeBottomNav(),
       body: Center(
         child: SingleChildScrollView(
@@ -73,10 +73,22 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  AppBar appBar(int dayId) {
+  AppBar appBar(Day currentDay, int dayId) {
     return AppBar(
       title: TextButton(
-        onPressed: () {},
+        onPressed: () async {
+          final provider = context.read<DayProvider>();
+          final firstDate = await provider.findFirst();
+
+          if(!mounted || firstDate == null) return;
+
+          showDatePicker(
+            context: context,
+            initialDate: currentDay.date.toLocal(),
+            firstDate: firstDate.date.toLocal(), 
+            lastDate: currentDay.date.toLocal(),
+          );
+        },
         style: TextButton.styleFrom(
           padding: EdgeInsets.zero,
         ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -97,7 +97,10 @@ class _HomePageState extends State<HomePage> {
           if(loadedDay == null && mounted) {
             ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(
-                content: Text('Day not found'),
+                content: Text(
+                  'Day not found',
+                  style: AppTheme.darkTheme.textTheme.bodyLarge,
+                ),
               )
             );
             return;

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -89,6 +89,17 @@ class _HomePageState extends State<HomePage> {
             initialDate: latestDate.date.toLocal(),
             firstDate: firstDate.date.toLocal(),
             lastDate: latestDate.date.toLocal(),
+            builder:(context, child) {
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  colorScheme: ColorScheme.dark(
+                    primary: AppColors.blueAccent,
+                    onSurface: AppColors.primaryText,
+                  ),
+                ),
+                child: child!,
+              );
+            },
           );
 
           if(pickedDate == null) return;

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -5,6 +5,7 @@ import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
+import 'package:hidroly/theme/app_theme.dart';
 import 'package:hidroly/widgets/home/daily_history_bottom_sheet.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
@@ -74,8 +75,23 @@ class _HomePageState extends State<HomePage> {
 
   AppBar appBar(int dayId) {
     return AppBar(
-      title: Text(
-        'Today',
+      title: TextButton(
+        onPressed: () {},
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.zero,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Today',
+              style: AppTheme.darkTheme.appBarTheme.titleTextStyle,
+            ),
+            Icon(
+              Icons.arrow_drop_down
+            ),
+          ],
+        ),
       ),
       actions: [
         IconButton(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -140,15 +140,17 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadDay() async {
     final provider = context.read<DayProvider>();
+    final latestDay = await provider.findLatest();
 
-    await provider.findLatest();
-    if(provider.day == null && mounted) {
+    if(latestDay == null && mounted) {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => SetupPage()),
       );
       return;
     }
+
+    provider.day = latestDay;
   }
 
   Future<void> _loadCustomCups() async {

--- a/lib/pages/setup_page.dart
+++ b/lib/pages/setup_page.dart
@@ -71,6 +71,9 @@ class _SetupPageState extends State<SetupPage> {
         icon: Icon(
           Icons.arrow_forward,
         ),
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.white,
+        ),
         padding: EdgeInsets.all(18),
       ),
     );

--- a/lib/provider/day_provider.dart
+++ b/lib/provider/day_provider.dart
@@ -48,6 +48,10 @@ class DayProvider extends ChangeNotifier {
     }
   }
 
+  Future<Day?> findFirst() async {
+    return await _repository.findFirst();
+  }
+
   Future<Day?> findLatest() async {
     return await _repository.findLatest();
   }

--- a/lib/provider/day_provider.dart
+++ b/lib/provider/day_provider.dart
@@ -33,11 +33,13 @@ class DayProvider extends ChangeNotifier {
   Future<void> createAndLoadIfNewDay() async {
     if(_day == null) return;
 
+    final localDate = DateTime.now();
+
     final currentAppDate = AppDateUtils.normalizedLocal(day!.date.toLocal());
-    final currentDate = AppDateUtils.normalizedLocal(DateTime.now());
+    final currentDate = AppDateUtils.normalizedLocal(localDate);
 
     if (currentAppDate != currentDate) {
-      await create(currentDate, _day!.dailyGoal);
+      await create(localDate, _day!.dailyGoal);
       await findLatest();
     }
   }

--- a/lib/provider/day_provider.dart
+++ b/lib/provider/day_provider.dart
@@ -8,6 +8,10 @@ class DayProvider extends ChangeNotifier {
 
   Day? _day;
   Day? get day => _day;
+  set day(Day? value) {
+    _day = value;
+    notifyListeners();
+  }
 
   void setRepository(DayRepository repository) {
     _repository = repository;
@@ -35,7 +39,7 @@ class DayProvider extends ChangeNotifier {
 
     final localDate = DateTime.now();
 
-    final currentAppDate = AppDateUtils.normalizedLocal(day!.date.toLocal());
+    final currentAppDate = AppDateUtils.normalizedLocal(_day!.date.toLocal());
     final currentDate = AppDateUtils.normalizedLocal(localDate);
 
     if (currentAppDate != currentDate) {
@@ -44,19 +48,13 @@ class DayProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> findLatest() async {
-    Day? latestDay = await _repository.findLatest();
-
-    if(latestDay != null) {
-      _day = latestDay;
-    }
-
-    notifyListeners();
+  Future<Day?> findLatest() async {
+    return await _repository.findLatest();
   }
   
   Future<void> update(Day updatedDay) async {
     await _repository.update(updatedDay);
-    await findLatest();
+    day = updatedDay;
   }
 
   Future<void> addWater(int amount) async {

--- a/lib/provider/day_provider.dart
+++ b/lib/provider/day_provider.dart
@@ -48,6 +48,10 @@ class DayProvider extends ChangeNotifier {
     }
   }
 
+  Future<Day?> findByDate(DateTime date) async {
+    return await _repository.findByDate(date);
+  }
+
   Future<Day?> findFirst() async {
     return await _repository.findFirst();
   }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -95,6 +95,8 @@ class AppTheme {
         dayForegroundColor: WidgetStateProperty.resolveWith<Color>((state) {
           if(state.contains(WidgetState.disabled)) {
             return AppColors.unselectedItem;
+          } else if(state.contains(WidgetState.selected)) {
+            return AppColors.onBackground;
           } else {
             return AppColors.secondaryText;
           }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -11,6 +11,7 @@ class AppTheme {
         primary: AppColors.blueAccent,
         surface: AppColors.background,
         onSurface: AppColors.onBackground,
+        outlineVariant: Colors.transparent,
       ),
       appBarTheme: AppBarTheme(
         backgroundColor: AppColors.background,
@@ -43,11 +44,6 @@ class AppTheme {
         ),
       ),
       iconTheme: IconThemeData(color: AppColors.icon),
-      iconButtonTheme: IconButtonThemeData(
-        style: IconButton.styleFrom(
-          backgroundColor: Colors.white,
-        )
-      ),
       inputDecorationTheme: InputDecorationTheme(
         fillColor: AppColors.onBackground,
         filled: true,
@@ -76,6 +72,33 @@ class AppTheme {
             borderRadius: BorderRadius.circular(16),
           ),
         ),
+      ),
+      datePickerTheme: DatePickerThemeData(
+        backgroundColor: AppColors.background,
+        headerBackgroundColor: AppColors.onBackground,
+        headerForegroundColor: AppColors.secondaryText,
+
+        weekdayStyle: TextStyle(
+          color: AppColors.secondaryText,
+        ),
+
+        dividerColor: Colors.transparent,
+      
+        yearForegroundColor: WidgetStateProperty.resolveWith<Color>((state) {
+          if(state.contains(WidgetState.disabled)) {
+            return AppColors.unselectedItem;
+          } else {
+            return AppColors.primaryText;
+          }
+        }),
+
+        dayForegroundColor: WidgetStateProperty.resolveWith<Color>((state) {
+          if(state.contains(WidgetState.disabled)) {
+            return AppColors.unselectedItem;
+          } else {
+            return AppColors.secondaryText;
+          }
+        }),
       ),
       fontFamily: 'Poppins',
     );

--- a/lib/utils/app_date_utils.dart
+++ b/lib/utils/app_date_utils.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 class AppDateUtils {
   /// Takes a *local* date and returns [YYYY-MM-DD 00:00:00.000].
   static DateTime normalizedLocal(DateTime localDate) {
@@ -6,5 +8,16 @@ class AppDateUtils {
       localDate.month,
       localDate.day,
     );
+  }
+
+  static String formatDayTitle(DateTime localDate, { String todayText = 'Today' }) {
+    localDate = localDate.toLocal();
+    DateTime now = DateTime.now();
+
+    if(localDate.day == now.day && localDate.month == now.month && localDate.year == now.year) {
+      return todayText;
+    }
+
+    return DateFormat.yMMMMd().format(localDate);
   }
 }

--- a/lib/widgets/home/daily_history_bottom_sheet.dart
+++ b/lib/widgets/home/daily_history_bottom_sheet.dart
@@ -39,7 +39,7 @@ class DailyHistoryBottomSheet extends StatelessWidget {
                         ),
                       ),
                       Text(
-                        'Today\'s history',
+                        'Day history',
                         style: TextStyle(
                           color: AppColors.primaryText
                         ),
@@ -60,7 +60,7 @@ class DailyHistoryBottomSheet extends StatelessWidget {
                               color: AppColors.secondaryText,
                               size: 48,
                             ),
-                            Text('No entries today.')
+                            Text('Nothing here :(')
                           ],
                         ),
                       ),


### PR DESCRIPTION
This PR adds the ability for users to select and navigate to previous days using a date picker integrated into the app bar. 

Key changes include:
 - Replaced static "Today" title with a clickable widget that opens a date picker
 - Date picker respects the range between the earliest recorded day and the current day
 - Loading and displaying data for the selected day seamlessly
 - Date formatting utility updated to show "Today" for the current day and formatted dates otherwise
 - Improved user experience for accessing historical daily data

This should fix #15 and close #17.