### PR TITLE
 Prevent excessive notifications by saving last notification timestamp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,58 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/config/providers.dart';
-import 'package:hidroly/data/model/enum/settings.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/pages/home_page.dart';
 import 'package:hidroly/services/notification_service.dart';
+import 'package:hidroly/services/work_manager_service.dart';
 import 'package:hidroly/theme/app_theme.dart';
-import 'package:hidroly/utils/app_date_utils.dart';
 import 'package:provider/provider.dart';
-import 'package:workmanager/workmanager.dart';
-
-@pragma('vm:entry-point')
-void callbackDispatcher() {
-  Workmanager().executeTask((task, inputData) async {
-    if(task == 'notificationTask') {
-      if(inputData == null) {
-        return Future.value(false);
-      }
-
-      TimeOfDay wakeUpTime = AppDateUtils.parseTime(inputData[Settings.wakeUpTime.value]);
-      TimeOfDay sleepTime = AppDateUtils.parseTime(inputData[Settings.sleepTime.value]);
-      TimeOfDay now = TimeOfDay.now();
-
-      String title = inputData['title'];
-      String body = inputData['body'];
-
-      bool isOnTimeRange = now.isAfter(wakeUpTime) && now.isBefore(sleepTime);
-      if(sleepTime.hour < wakeUpTime.hour) {
-        // When the time range crosses midnight, for example from 10:00 PM to 6:00 AM,
-        // we check if the current time is after the wake-up time (10:00 PM)
-        // or before the sleep time (6:00 AM) to cover the overnight period.
-        isOnTimeRange = now.isAfter(wakeUpTime) || now.isBefore(sleepTime);
-      }
-
-      if(isOnTimeRange) {
-        final notificationService = NotificationService();
-        await notificationService.initialize();
-        await notificationService.showNotification(
-          title,
-          body,
-        );
-      }
-    }
-    return Future.value(true);
-  });
-}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   
+  await WorkManagerService().initialize();
   await NotificationService().initialize();
-  await Workmanager().initialize(
-    callbackDispatcher,
-    isInDebugMode: false
-  );
 
   runApp(
     MultiProvider(

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -49,10 +49,15 @@ class NotificationService {
     );
   }
 
-  Future<bool> registerPeriodicNotificationTask(BuildContext context, SettingsProvider settingsProvider) async {
+  Future<bool> registerPeriodicNotificationTask(
+    BuildContext context, 
+    SettingsProvider settingsProvider
+  ) async {
     if(settingsProvider.wakeUpTime == null || settingsProvider.sleepTime == null) {
       return false;
     }
+
+    final workManager = Workmanager();
 
     final formattedWakeUpTime = AppDateUtils.formatTime(
       settingsProvider.wakeUpTime!.hour, 
@@ -64,10 +69,10 @@ class NotificationService {
       settingsProvider.sleepTime!.minute
     );
     
-    await Workmanager().cancelAll();
+    await workManager.cancelAll();
     
     if(!context.mounted) return false;
-    await Workmanager().registerPeriodicTask(
+    await workManager.registerPeriodicTask(
       'notification',
       'notificationTask',
       frequency: Duration(hours: 2),

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -75,7 +75,7 @@ class NotificationService {
     await workManager.registerPeriodicTask(
       'notification',
       'notificationTask',
-      frequency: Duration(hours: 2),
+      frequency: Duration(hours: 1),
       inputData: {
         Settings.wakeUpTime.value: formattedWakeUpTime,
         Settings.sleepTime.value: formattedSleepTime,

--- a/lib/services/work_manager_service.dart
+++ b/lib/services/work_manager_service.dart
@@ -13,7 +13,7 @@ class WorkManagerService {
     );
   }
 
-  Future<void> executeNotificationTask(Map<String, dynamic> inputData) async {
+  static Future<void> executeNotificationTask(Map<String, dynamic> inputData) async {
     final sharedPreferences = SharedPreferencesAsync();
     final now = DateTime.now();
 
@@ -46,15 +46,16 @@ class WorkManagerService {
   }
 
   @pragma('vm:entry-point')
-  void callbackDispatcher() {
+  static void callbackDispatcher() {
     Workmanager().executeTask((task, inputData) async {
       if(task == 'notificationTask') {
         if(inputData == null) {
           return Future.value(false);
         }
 
-        executeNotificationTask(inputData);
+        await executeNotificationTask(inputData);
       }
+      
       return Future.value(true);
     });
   }

--- a/lib/services/work_manager_service.dart
+++ b/lib/services/work_manager_service.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/settings.dart';
+import 'package:hidroly/services/notification_service.dart';
+import 'package:hidroly/utils/app_date_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:workmanager/workmanager.dart';
+
+class WorkManagerService {
+  Future<void> initialize() async {
+    await Workmanager().initialize(
+      callbackDispatcher,
+      isInDebugMode: false
+    );
+  }
+
+  Future<void> executeNotificationTask(
+    Map<String, dynamic> inputData
+  ) async {
+    TimeOfDay wakeUpTime = AppDateUtils.parseTime(inputData[Settings.wakeUpTime.value]);
+    TimeOfDay sleepTime = AppDateUtils.parseTime(inputData[Settings.sleepTime.value]);
+    TimeOfDay now = TimeOfDay.now();
+
+    String title = inputData['title'];
+    String body = inputData['body'];
+
+    bool isOnTimeRange = AppDateUtils.isWithinTimeRange(now, wakeUpTime, sleepTime);
+
+    if(isOnTimeRange) {
+      final notificationService = NotificationService();
+      await notificationService.initialize();
+      await notificationService.showNotification(
+        title,
+        body,
+      );
+    }
+  }
+
+  @pragma('vm:entry-point')
+  void callbackDispatcher() {
+    Workmanager().executeTask((task, inputData) async {
+      if(task == 'notificationTask') {
+        if(inputData == null) {
+          return Future.value(false);
+        }
+
+        executeNotificationTask(inputData);
+      }
+      return Future.value(true);
+    });
+  }
+}

--- a/lib/utils/app_date_utils.dart
+++ b/lib/utils/app_date_utils.dart
@@ -37,4 +37,17 @@ class AppDateUtils {
     final dateTime = format.parse(formattedTime);
     return TimeOfDay.fromDateTime(dateTime);
   }
+
+  static bool isWithinTimeRange(TimeOfDay now, TimeOfDay startTime, TimeOfDay endTime) {
+    bool isOnTimeRange = now.isAfter(startTime) && now.isBefore(endTime);
+
+    // When the time range crosses midnight, for example from 10:00 PM to 6:00 AM,
+    // we check if the current time is after the wake-up time (10:00 PM)
+    // or before the sleep time (6:00 AM) to cover the overnight period.
+    if(endTime.hour < startTime.hour) {
+      isOnTimeRange = now.isAfter(startTime) || now.isBefore(endTime);
+    }
+    
+    return isOnTimeRange;
+  }
 }


### PR DESCRIPTION
This PR fixes the issue of excessive notification sending by properly saving the timestamp of the last notification sent in SharedPreferences. Before sending a new notification, the app now checks if at least 2 hours have elapsed since the previous one.