### PR TITLE
Move custom cup button to a floating action button

### DIFF
--- a/lib/data/datasource/custom_cups_local_datasource_impl.dart
+++ b/lib/data/datasource/custom_cups_local_datasource_impl.dart
@@ -25,7 +25,7 @@ class CustomCupsLocalDataSourceImpl {
 
     return [
       for(final { 'id': id as int, 'amount': amount as int } in customCups)
-        WaterButton(id: id, amount: amount, isCustomOption: false),
+        WaterButton(id: id, amount: amount),
     ];
   }
 }

--- a/lib/data/model/water_button.dart
+++ b/lib/data/model/water_button.dart
@@ -1,12 +1,10 @@
 class WaterButton {
   final int? id;
   final int amount;
-  final bool isCustomOption;
 
   const WaterButton({
     this.id,
     required this.amount,
-    this.isCustomOption = false,
   });
 
   Map<String, Object?> toMap() {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -13,6 +13,7 @@ import 'package:hidroly/theme/app_theme.dart';
 import 'package:hidroly/utils/app_date_utils.dart';
 import 'package:hidroly/widgets/common/icon_header.dart';
 import 'package:hidroly/widgets/home/daily_history_bottom_sheet.dart';
+import 'package:hidroly/widgets/home/fab_custom_cup.dart';
 import 'package:hidroly/widgets/home/home_bottom_nav.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
 import 'package:hidroly/widgets/home/water_progress_circle.dart';
@@ -84,8 +85,6 @@ class _HomePageState extends State<HomePage> {
                   ),
                   WaterActionButtons(
                     dayId: dayId,
-                    customCupAmountController: customCupAmountController,
-                    formKey: formKey,
                     isMetric: isMetric,
                   )
                 ],
@@ -105,6 +104,12 @@ class _HomePageState extends State<HomePage> {
               )
           ),
         ),
+      ),
+      floatingActionButton: FabCustomCup(
+        dayId: dayId,
+        customCupAmountController: customCupAmountController,
+        formKey: formKey,
+        isMetric: isMetric
       ),
     );
   }

--- a/lib/widgets/home/fab_custom_cup.dart
+++ b/lib/widgets/home/fab_custom_cup.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/history_entry.dart';
+import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/provider/custom_cups_provider.dart';
+import 'package:hidroly/provider/daily_history_provider.dart';
+import 'package:hidroly/provider/day_provider.dart';
+import 'package:hidroly/theme/app_colors.dart';
+import 'package:hidroly/utils/unit_tools.dart';
+import 'package:hidroly/widgets/input/form_number_input_field.dart';
+import 'package:provider/provider.dart';
+
+class FabCustomCup extends StatelessWidget {
+  const FabCustomCup({
+    super.key,
+    required this.dayId,
+    required this.customCupAmountController,
+    required this.formKey,
+    required this.isMetric,
+  });
+
+  final TextEditingController customCupAmountController;
+  final GlobalKey<FormState> formKey;
+  
+  final int dayId;
+  final bool isMetric;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => _showCustomCupPopUp(context),
+      backgroundColor: AppColors.onBackground,
+      child: Icon(
+        Icons.add,
+        color: AppColors.primaryText,
+      ),
+    );
+  }
+
+  void _showCustomCupPopUp(context) {
+    showDialog(
+      context: context, 
+      builder: (context) {
+        bool doNotSaveCup = true;
+
+        return AlertDialog(
+          title: Text(
+            AppLocalizations.of(context)!.customCupDialogTitle,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          content: Form(
+            key: formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FormNumberInputField(
+                  label: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
+                  decimal: !isMetric,
+                  maxLength: 4,
+                  controller: customCupAmountController, 
+                  validator: (value) {
+                    double? amount = double.tryParse(value ?? '');
+                    if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
+                    return null;
+                  }
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    StatefulBuilder(
+                      builder: (context, setState) {
+                        return Checkbox(
+                          value: doNotSaveCup, 
+                          onChanged: (value) {
+                            setState(() => doNotSaveCup = value!);
+                          }
+                        );
+                      }
+                    ),
+                    Text(
+                      AppLocalizations.of(context)!.doNotSaveLabel,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                if(!formKey.currentState!.validate()) return;
+                bool success = false;
+                
+                double? amount = double.tryParse(customCupAmountController.text);
+                if(amount == null) return;
+
+                if(doNotSaveCup) {
+                  int formattedAmount = 
+                    isMetric ? amount.round() : UnitTools.flOzToMl(amount);
+                  
+                  success = await context
+                    .read<DayProvider>()
+                    .addWater(formattedAmount);
+
+                  if(!context.mounted) return;
+                  await context.read<DailyHistoryProvider>().create(
+                    HistoryEntry(
+                      dayId: dayId, 
+                      amount: formattedAmount, 
+                      dateTime: DateTime.now().toUtc()
+                    )
+                  );
+                } else {
+                  success = await context.read<CustomCupsProvider>().createCustomCup(
+                    isMetric ? amount.round() : UnitTools.flOzToMl(amount)
+                  );
+                }
+
+                if(!context.mounted) return;
+                if(!success) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(AppLocalizations.of(context)!.waterAddFailed)
+                    )
+                  );
+                }
+
+                Navigator.of(context).pop();
+                customCupAmountController.clear();
+              }, 
+              child: Text(
+                AppLocalizations.of(context)!.addAction,
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context), 
+              child: Text(
+                AppLocalizations.of(context)!.cancelAction,
+              ),
+            ),
+          ],
+          backgroundColor: Theme.of(context).colorScheme.surface,
+        );
+      }
+    );
+  }
+}

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -26,7 +26,6 @@ class WaterActionButtons extends StatelessWidget {
   });
 
   final _defaultButtons = [WaterButton(amount: 250), WaterButton(amount: 350)];
-  final _addCustomCupButton = WaterButton(amount: 0, isCustomOption: true);
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +35,6 @@ class WaterActionButtons extends StatelessWidget {
     List<WaterButton> allButtons = [
       ..._defaultButtons,
       ...customCups,
-      _addCustomCupButton,
     ];
 
     return Container(
@@ -50,11 +48,6 @@ class WaterActionButtons extends StatelessWidget {
 
           return ElevatedButton.icon(
             onPressed: () async {
-              if(button.isCustomOption) {
-                _showCustomCupPopUp(context);
-                return;
-              }
-
               final int amount = button.amount;
               await addWater(context, amount);
 
@@ -67,14 +60,9 @@ class WaterActionButtons extends StatelessWidget {
                 borderRadius: BorderRadiusGeometry.circular(16)
               ),
             ),
-            icon: Icon(
-              button.isCustomOption == false 
-              ? Icons.water_drop : Icons.add,
-            ),
+            icon: Icon(Icons.water_drop),
             label: Text(
-              button.isCustomOption == false 
-                ? UnitTools.getVolumeWithUnit(button.amount, isMetric, context: context) 
-                : AppLocalizations.of(context)!.customCupButton,
+              UnitTools.getVolumeWithUnit(button.amount, isMetric, context: context),
               style: TextStyle(
                 color: AppColors.secondaryText
               ),

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -7,24 +7,17 @@ import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/utils/unit_tools.dart';
-import 'package:hidroly/widgets/input/form_number_input_field.dart';
 import 'package:provider/provider.dart';
 
 class WaterActionButtons extends StatelessWidget {
-  final TextEditingController customCupAmountController;
-  final GlobalKey<FormState> formKey;
-  final int dayId;
-
-  final bool isMetric;
-
   WaterActionButtons({
     super.key,
     required this.dayId,
-    required this.customCupAmountController,
-    required this.formKey,
     required this.isMetric,
   });
 
+  final int dayId;
+  final bool isMetric;
   final _defaultButtons = [WaterButton(amount: 250), WaterButton(amount: 350)];
 
   @override
@@ -72,101 +65,6 @@ class WaterActionButtons extends StatelessWidget {
         separatorBuilder: (context, index) => SizedBox(width: 10,), 
         itemCount: allButtons.length
       ),
-    );
-  }
-
-  void _showCustomCupPopUp(context) {
-    showDialog(
-      context: context, 
-      builder: (context) {
-        bool doNotSaveCup = false;
-
-        return AlertDialog(
-          title: Text(
-            AppLocalizations.of(context)!.customCupDialogTitle,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          content: Form(
-            key: formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                FormNumberInputField(
-                  label: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
-                  decimal: !isMetric,
-                  maxLength: 4,
-                  controller: customCupAmountController, 
-                  validator: (value) {
-                    double? amount = double.tryParse(value ?? '');
-                    if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
-                    return null;
-                  }
-                ),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    StatefulBuilder(
-                      builder: (context, setState) {
-                        return Checkbox(
-                          value: doNotSaveCup, 
-                          onChanged: (value) {
-                            setState(() => doNotSaveCup = value!);
-                          }
-                        );
-                      }
-                    ),
-                    Text(
-                      AppLocalizations.of(context)!.doNotSaveLabel,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () async {
-                if(!formKey.currentState!.validate()) return;
-                bool success = false;
-                
-                double? amount = double.tryParse(customCupAmountController.text);
-                if(amount == null) return;
-
-                if(doNotSaveCup) {
-                  int formattedAmount = 
-                    isMetric ? amount.round() : UnitTools.flOzToMl(amount);
-                  
-                  success = await addWater(context, formattedAmount);
-                  if(!success || !context.mounted) return;
-
-                  await saveWaterToHistory(context, formattedAmount);
-                } else {
-                  success = await context.read<CustomCupsProvider>().createCustomCup(
-                    isMetric ? amount.round() : UnitTools.flOzToMl(amount)
-                  );
-                }
-
-                if(success && context.mounted) {
-                  Navigator.of(context).pop();
-                  customCupAmountController.clear();
-                }
-              }, 
-              child: Text(
-                AppLocalizations.of(context)!.addAction,
-              ),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context), 
-              child: Text(
-                AppLocalizations.of(context)!.cancelAction,
-              ),
-            ),
-          ],
-          backgroundColor: Theme.of(context).colorScheme.surface,
-        );
-      }
     );
   }
 


### PR DESCRIPTION
# Description
This update introduces a enhancement to the custom cup button functionality. Users will now find the custom cup button as a floating action button (FAB) on the home page, rather than within the presets list view. This change is related to the issue #41.

# Changes
* Removed the custom cup button from the presets list view.
* Added a floating action button (FAB) on the home page, maintaining the same functionality as the previous button.