### PR TITLE
Fix: Update Weight Validation Logic for Metric and Imperial Units

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,9 +27,9 @@
     "setupAgeTextFieldLabel": "Your age",
     "setupAgeTextFieldInvalidValue": "Age between 10 and 120",
     "setupWeightTextFieldLabel": "Your weight",
-    "setupWeightTextFieldInvalidWeight": "Value not supported",
-    "setupWeightTextFieldInvalidValue": "Weight between {minWeight} and {maxWeight}",
-    "@setupWeightTextFieldInvalidValue": {
+    "valueNotSupported": "Value not supported",
+    "setupWeightTextFieldInvalidWeight": "Weight between {minWeight} and {maxWeight}",
+    "@setupWeightTextFieldInvalidWeight": {
         "placeholders": {
             "minWeight": {
                 "type": "String",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,7 +27,6 @@
     "setupAgeTextFieldLabel": "Your age",
     "setupAgeTextFieldInvalidValue": "Age between 10 and 120",
     "setupWeightTextFieldLabel": "Your weight",
-    "valueNotSupported": "Value not supported",
     "setupWeightTextFieldInvalidWeight": "Weight between {minWeight} and {maxWeight}",
     "@setupWeightTextFieldInvalidWeight": {
         "placeholders": {
@@ -82,5 +81,6 @@
     "sleepScheduleEditFailed": "Could not save your sleep schedule",
     "notificationTaskCreationFailed": "Failed to create the notification task",
     "pageNotAvailableTitle": "Not Available",
-    "pageNotAvailableDescription": "Sorry, this page isn't available yet :("
+    "pageNotAvailableDescription": "Sorry, this page isn't available yet :(",
+    "valueNotSupported": "Value not supported"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,7 +27,20 @@
     "setupAgeTextFieldLabel": "Your age",
     "setupAgeTextFieldInvalidValue": "Age between 10 and 120",
     "setupWeightTextFieldLabel": "Your weight",
-    "setupWeightTextFieldInvalidValue": "Weight between 30 and 200",
+    "setupWeightTextFieldInvalidWeight": "Value not supported",
+    "setupWeightTextFieldInvalidValue": "Weight between {minWeight} and {maxWeight}",
+    "@setupWeightTextFieldInvalidValue": {
+        "placeholders": {
+            "minWeight": {
+                "type": "String",
+                "example": "30"
+            },
+            "maxWeight": {
+                "type": "String",
+                "example": "200"
+            }
+        }
+    },
     "setupUnitMetric": "kg, ml",
     "setupUnitImperial": "lb, fl oz",
     "homePageTodayAppBarTitle": "Today",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -218,11 +218,17 @@ abstract class AppLocalizations {
   /// **'Your weight'**
   String get setupWeightTextFieldLabel;
 
+  /// No description provided for @setupWeightTextFieldInvalidWeight.
+  ///
+  /// In en, this message translates to:
+  /// **'Value not supported'**
+  String get setupWeightTextFieldInvalidWeight;
+
   /// No description provided for @setupWeightTextFieldInvalidValue.
   ///
   /// In en, this message translates to:
-  /// **'Weight between 30 and 200'**
-  String get setupWeightTextFieldInvalidValue;
+  /// **'Weight between {minWeight} and {maxWeight}'**
+  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight);
 
   /// No description provided for @setupUnitMetric.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -218,17 +218,17 @@ abstract class AppLocalizations {
   /// **'Your weight'**
   String get setupWeightTextFieldLabel;
 
-  /// No description provided for @setupWeightTextFieldInvalidWeight.
+  /// No description provided for @valueNotSupported.
   ///
   /// In en, this message translates to:
   /// **'Value not supported'**
-  String get setupWeightTextFieldInvalidWeight;
+  String get valueNotSupported;
 
-  /// No description provided for @setupWeightTextFieldInvalidValue.
+  /// No description provided for @setupWeightTextFieldInvalidWeight.
   ///
   /// In en, this message translates to:
   /// **'Weight between {minWeight} and {maxWeight}'**
-  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight);
+  String setupWeightTextFieldInvalidWeight(String minWeight, String maxWeight);
 
   /// No description provided for @setupUnitMetric.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -72,7 +72,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get setupWeightTextFieldLabel => 'Your weight';
 
   @override
-  String get setupWeightTextFieldInvalidValue => 'Weight between 30 and 200';
+  String get setupWeightTextFieldInvalidWeight => 'Value not supported';
+
+  @override
+  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight) {
+    return 'Weight between $minWeight and $maxWeight';
+  }
 
   @override
   String get setupUnitMetric => 'kg, ml';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get setupWeightTextFieldLabel => 'Your weight';
 
   @override
-  String get setupWeightTextFieldInvalidWeight => 'Value not supported';
+  String get valueNotSupported => 'Value not supported';
 
   @override
-  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight) {
+  String setupWeightTextFieldInvalidWeight(String minWeight, String maxWeight) {
     return 'Weight between $minWeight and $maxWeight';
   }
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -73,10 +73,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get setupWeightTextFieldLabel => 'Seu peso';
 
   @override
-  String get setupWeightTextFieldInvalidWeight => 'Value not supported';
+  String get valueNotSupported => 'Valor não suportado';
 
   @override
-  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight) {
+  String setupWeightTextFieldInvalidWeight(String minWeight, String maxWeight) {
     return 'Peso entre $minWeight e $maxWeight';
   }
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -73,7 +73,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get setupWeightTextFieldLabel => 'Seu peso';
 
   @override
-  String get setupWeightTextFieldInvalidValue => 'Peso entre 30 e 200';
+  String get setupWeightTextFieldInvalidWeight => 'Value not supported';
+
+  @override
+  String setupWeightTextFieldInvalidValue(String minWeight, String maxWeight) {
+    return 'Peso entre $minWeight e $maxWeight';
+  }
 
   @override
   String get setupUnitMetric => 'kg, ml';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -27,7 +27,19 @@
   "setupAgeTextFieldLabel": "Sua idade",
   "setupAgeTextFieldInvalidValue": "Idade entre 10 e 120",
   "setupWeightTextFieldLabel": "Seu peso",
-  "setupWeightTextFieldInvalidValue": "Peso entre 30 e 200",
+  "setupWeightTextFieldInvalidValue": "Peso entre {minWeight} e {maxWeight}",
+  "@setupWeightTextFieldInvalidValue": {
+      "placeholders": {
+          "minWeight": {
+              "type": "String",
+              "example": "30"
+          },
+          "maxWeight": {
+              "type": "String",
+              "example": "200"
+          }
+      }
+  },
   "setupUnitMetric": "kg, ml",
   "setupUnitImperial": "lb, fl oz",
   "homePageTodayAppBarTitle": "Hoje",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -27,8 +27,9 @@
   "setupAgeTextFieldLabel": "Sua idade",
   "setupAgeTextFieldInvalidValue": "Idade entre 10 e 120",
   "setupWeightTextFieldLabel": "Seu peso",
-  "setupWeightTextFieldInvalidValue": "Peso entre {minWeight} e {maxWeight}",
-  "@setupWeightTextFieldInvalidValue": {
+  "valueNotSupported": "Valor não suportado",
+  "setupWeightTextFieldInvalidWeight": "Peso entre {minWeight} e {maxWeight}",
+  "@setupWeightTextFieldInvalidWeight": {
       "placeholders": {
           "minWeight": {
               "type": "String",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -27,7 +27,6 @@
   "setupAgeTextFieldLabel": "Sua idade",
   "setupAgeTextFieldInvalidValue": "Idade entre 10 e 120",
   "setupWeightTextFieldLabel": "Seu peso",
-  "valueNotSupported": "Valor não suportado",
   "setupWeightTextFieldInvalidWeight": "Peso entre {minWeight} e {maxWeight}",
   "@setupWeightTextFieldInvalidWeight": {
       "placeholders": {
@@ -82,5 +81,6 @@
   "sleepScheduleEditFailed": "Não foi possível salvar seu horário de sono",
   "notificationTaskCreationFailed": "Falha ao criar a tarefa de notificação",
   "pageNotAvailableTitle": "Indisponível",
-  "pageNotAvailableDescription": "Desculpa, essa página ainda não tá disponível :("
+  "pageNotAvailableDescription": "Desculpa, essa página ainda não tá disponível :(",
+  "valueNotSupported": "Valor não suportado"
 }

--- a/lib/pages/settings/settings_update_daily_goal_page.dart
+++ b/lib/pages/settings/settings_update_daily_goal_page.dart
@@ -8,7 +8,12 @@ import 'package:hidroly/widgets/common/icon_header.dart';
 import 'package:provider/provider.dart';
 
 class SettingsUpdateDailyGoalPage extends StatefulWidget {
-  const SettingsUpdateDailyGoalPage({super.key});
+  final bool isMetric;
+
+  const SettingsUpdateDailyGoalPage({
+    super.key,
+    required this.isMetric,
+  });
 
   @override
   State<SettingsUpdateDailyGoalPage> createState() => _SettingsUpdateDailyGoalPageState();
@@ -18,6 +23,15 @@ class _SettingsUpdateDailyGoalPageState extends State<SettingsUpdateDailyGoalPag
   final ageController = TextEditingController();
   final weightController = TextEditingController();
   final formKey = GlobalKey<FormState>();
+
+  late ValueNotifier<bool> isMetricNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+
+    isMetricNotifier.value = widget.isMetric;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +66,7 @@ class _SettingsUpdateDailyGoalPageState extends State<SettingsUpdateDailyGoalPag
                     DailyGoalInput(
                       ageController: ageController, 
                       weightController: weightController,
+                      isMetric: isMetricNotifier,
                     ),
                   ],
                 ),

--- a/lib/pages/settings/settings_update_daily_goal_page.dart
+++ b/lib/pages/settings/settings_update_daily_goal_page.dart
@@ -3,6 +3,7 @@ import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/provider/day_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/utils/calculate_dailygoal.dart';
+import 'package:hidroly/utils/unit_tools.dart';
 import 'package:hidroly/widgets/common/daily_goal_input.dart';
 import 'package:hidroly/widgets/common/icon_header.dart';
 import 'package:provider/provider.dart';
@@ -29,8 +30,7 @@ class _SettingsUpdateDailyGoalPageState extends State<SettingsUpdateDailyGoalPag
   @override
   void initState() {
     super.initState();
-
-    isMetricNotifier.value = widget.isMetric;
+    isMetricNotifier = ValueNotifier<bool>(widget.isMetric);
   }
 
   @override
@@ -67,6 +67,7 @@ class _SettingsUpdateDailyGoalPageState extends State<SettingsUpdateDailyGoalPag
                       ageController: ageController, 
                       weightController: weightController,
                       isMetric: isMetricNotifier,
+                      showUnitToggleSwitch: false,
                     ),
                   ],
                 ),
@@ -84,7 +85,12 @@ class _SettingsUpdateDailyGoalPageState extends State<SettingsUpdateDailyGoalPag
           if(currentDay == null) return;
 
           final age = int.parse(ageController.text);
-          final weight = int.parse(weightController.text);
+          int weight = int.parse(weightController.text);
+
+          if(!isMetricNotifier.value) {
+            weight = UnitTools.lbToKg(weight);
+          }
+
           final newDailyGoal = CalculateDailyGoal().calculate(age, weight);
 
           dayProvider.update(

--- a/lib/widgets/common/daily_goal_input.dart
+++ b/lib/widgets/common/daily_goal_input.dart
@@ -44,14 +44,14 @@ class DailyGoalInput extends StatelessWidget {
               final maxWeight = isMetric.value ? 300 : 665;
 
               if(weight == null) {
-                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidWeight;
+                return AppLocalizations.of(context)!.valueNotSupported;
               }
 
               final isWeightValid =
                 weight >= minWeight && weight <= maxWeight;
 
               if(!isWeightValid) {
-                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue(
+                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidWeight(
                   minWeight.toString(),
                   maxWeight.toString(),
                 );

--- a/lib/widgets/common/daily_goal_input.dart
+++ b/lib/widgets/common/daily_goal_input.dart
@@ -7,13 +7,13 @@ import 'package:toggle_switch/toggle_switch.dart';
 class DailyGoalInput extends StatelessWidget {
   final TextEditingController ageController;
   final TextEditingController weightController;
-  final ValueNotifier<bool>? isMetric;
+  final ValueNotifier<bool> isMetric;
 
   const DailyGoalInput({
     super.key,
     required this.ageController,
     required this.weightController,
-    this.isMetric,
+    required this.isMetric,
   });
 
   @override
@@ -37,29 +37,45 @@ class DailyGoalInput extends StatelessWidget {
             label: AppLocalizations.of(context)!.setupWeightTextFieldLabel,
             validator: (value) {
               final weight = int.tryParse(value ?? '');
-              if(weight == null || weight < 30 || weight > 200) return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue;
+              
+              final minWeightInKg = 10;
+              final maxWeightInKg = 300;
+
+              final minWeightInLb = 25;
+              final maxWeightInLb = 665;
+
+              if(weight == null) {
+                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue;
+              }
+
+              final isWeightValid = isMetric.value
+                ? weight >= minWeightInKg && weight <= maxWeightInKg
+                : weight >= minWeightInLb && weight <= maxWeightInLb;
+
+              if(!isWeightValid) {
+                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue;
+              }
+              
               return null;
             },
           ),
-          if(isMetric != null) ...[
-            SizedBox(height: 5,),
-            ToggleSwitch(
-              initialLabelIndex: 0,
-              totalSwitches: 2,
-              activeBgColor: [AppColors.blueAccent],
-              activeFgColor: AppColors.primaryText,
-              inactiveBgColor: AppColors.onBackground,
-              inactiveFgColor: AppColors.secondaryText,
-              minWidth: 100,
-              labels: [
-                AppLocalizations.of(context)!.setupUnitMetric,
-                AppLocalizations.of(context)!.setupUnitImperial,
-              ],
-              onToggle: (index) {
-                isMetric!.value = (index == 0);
-              },
-            )
-          ]
+          SizedBox(height: 5,),
+          ToggleSwitch(
+            initialLabelIndex: 0,
+            totalSwitches: 2,
+            activeBgColor: [AppColors.blueAccent],
+            activeFgColor: AppColors.primaryText,
+            inactiveBgColor: AppColors.onBackground,
+            inactiveFgColor: AppColors.secondaryText,
+            minWidth: 100,
+            labels: [
+              AppLocalizations.of(context)!.setupUnitMetric,
+              AppLocalizations.of(context)!.setupUnitImperial,
+            ],
+            onToggle: (index) {
+              isMetric.value = (index == 0);
+            },
+          )
         ],
       ),
     );

--- a/lib/widgets/common/daily_goal_input.dart
+++ b/lib/widgets/common/daily_goal_input.dart
@@ -39,23 +39,22 @@ class DailyGoalInput extends StatelessWidget {
             label: AppLocalizations.of(context)!.setupWeightTextFieldLabel,
             validator: (value) {
               final weight = int.tryParse(value ?? '');
-              
-              final minWeightInKg = 10;
-              final maxWeightInKg = 300;
 
-              final minWeightInLb = 25;
-              final maxWeightInLb = 665;
+              final minWeight = isMetric.value ? 10 : 25;
+              final maxWeight = isMetric.value ? 300 : 665;
 
               if(weight == null) {
-                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue;
+                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidWeight;
               }
 
-              final isWeightValid = isMetric.value
-                ? weight >= minWeightInKg && weight <= maxWeightInKg
-                : weight >= minWeightInLb && weight <= maxWeightInLb;
+              final isWeightValid =
+                weight >= minWeight && weight <= maxWeight;
 
               if(!isWeightValid) {
-                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue;
+                return AppLocalizations.of(context)!.setupWeightTextFieldInvalidValue(
+                  minWeight.toString(),
+                  maxWeight.toString(),
+                );
               }
               
               return null;

--- a/lib/widgets/common/daily_goal_input.dart
+++ b/lib/widgets/common/daily_goal_input.dart
@@ -8,12 +8,14 @@ class DailyGoalInput extends StatelessWidget {
   final TextEditingController ageController;
   final TextEditingController weightController;
   final ValueNotifier<bool> isMetric;
+  final bool showUnitToggleSwitch;
 
   const DailyGoalInput({
     super.key,
     required this.ageController,
     required this.weightController,
     required this.isMetric,
+    this.showUnitToggleSwitch = true,
   });
 
   @override
@@ -59,23 +61,25 @@ class DailyGoalInput extends StatelessWidget {
               return null;
             },
           ),
-          SizedBox(height: 5,),
-          ToggleSwitch(
-            initialLabelIndex: 0,
-            totalSwitches: 2,
-            activeBgColor: [AppColors.blueAccent],
-            activeFgColor: AppColors.primaryText,
-            inactiveBgColor: AppColors.onBackground,
-            inactiveFgColor: AppColors.secondaryText,
-            minWidth: 100,
-            labels: [
-              AppLocalizations.of(context)!.setupUnitMetric,
-              AppLocalizations.of(context)!.setupUnitImperial,
-            ],
-            onToggle: (index) {
-              isMetric.value = (index == 0);
-            },
-          )
+          if(showUnitToggleSwitch) ...[
+            SizedBox(height: 5,),
+            ToggleSwitch(
+              initialLabelIndex: isMetric.value ? 0 : 1,
+              totalSwitches: 2,
+              activeBgColor: [AppColors.blueAccent],
+              activeFgColor: AppColors.primaryText,
+              inactiveBgColor: AppColors.onBackground,
+              inactiveFgColor: AppColors.secondaryText,
+              minWidth: 100,
+              labels: [
+                AppLocalizations.of(context)!.setupUnitMetric,
+                AppLocalizations.of(context)!.setupUnitImperial,
+              ],
+              onToggle: (index) {
+                isMetric.value = (index == 0);
+              },
+            )
+          ]
         ],
       ),
     );

--- a/lib/widgets/settings/sections/settings_you.dart
+++ b/lib/widgets/settings/sections/settings_you.dart
@@ -58,7 +58,9 @@ class _SettingsYouState extends State<SettingsYou> {
           description: dailyGoalDescription,
           onPressed: () async {
             final setNewDailyGoal = await Navigator.of(context).push(
-              MaterialPageRoute(builder: (context) => const SettingsUpdateDailyGoalPage()),
+              MaterialPageRoute(builder: (context) => SettingsUpdateDailyGoalPage(
+                isMetric: widget.isMetric,
+              )),
             );
 
             if((setNewDailyGoal != null && setNewDailyGoal) && context.mounted) {


### PR DESCRIPTION
# Description
This pull request addresses the weight validation logic to ensure that users can input their weight accurately based on their selected measurement system (metric or imperial).

# Changes
* Implemented separate minimum and maximum weight limits for both metric (kilograms, 10-300) and imperial (pounds, 25-665) systems.
* Added constants for minimum and maximum weight values to improve code readability and maintainability.
* Enhanced the validation logic to provide clear and dynamic error messages when the input weight is invalid or null.

Fixes #48.