### PR TITLE
feat: add new notification image and "update" text

### DIFF
--- a/assets/images/notifications.svg
+++ b/assets/images/notifications.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px" viewBox="0 0 24 24"><path d="M11.5 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6.5-6v-5.5c0-3.07-2.13-5.64-5-6.32V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5v.68c-2.87.68-5 3.25-5 6.32V16l-2 2v1h17v-1l-2-2z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -64,11 +64,11 @@
   "settingsSleepSchedule": "Edit sleep schedule",
   "settingsSleepScheduleAppBar": "Edit sleep schedule",
   "settingsSleepScheduleDescription": "Help us with a few details so we can update your sleep schedule",
-  "settingsSleepScheduleTitle": "Update",
+  "settingsSleepScheduleTitle": "Sleep Schedule",
   "settingsUnitSystem": "Unit system",
   "settingsUpdateDailyGoalAppBar": "Update Goal",
   "settingsUpdateDailyGoalDescription": "Help us with a few details so we can update your goal",
-  "settingsUpdateDailyGoalTitle": "Update",
+  "settingsUpdateDailyGoalTitle": "Daily Goal",
   "settingsUpdateYourDailyGoal": "Update your daily goal",
   "settingsYouSection": "You",
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -389,7 +389,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsSleepScheduleTitle.
   ///
   /// In en, this message translates to:
-  /// **'Update'**
+  /// **'Sleep Schedule'**
   String get settingsSleepScheduleTitle;
 
   /// No description provided for @settingsUnitSystem.
@@ -413,7 +413,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsUpdateDailyGoalTitle.
   ///
   /// In en, this message translates to:
-  /// **'Update'**
+  /// **'Daily Goal'**
   String get settingsUpdateDailyGoalTitle;
 
   /// No description provided for @settingsUpdateYourDailyGoal.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -161,7 +161,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Help us with a few details so we can update your sleep schedule';
 
   @override
-  String get settingsSleepScheduleTitle => 'Update';
+  String get settingsSleepScheduleTitle => 'Sleep Schedule';
 
   @override
   String get settingsUnitSystem => 'Unit system';
@@ -174,7 +174,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Help us with a few details so we can update your goal';
 
   @override
-  String get settingsUpdateDailyGoalTitle => 'Update';
+  String get settingsUpdateDailyGoalTitle => 'Daily Goal';
 
   @override
   String get settingsUpdateYourDailyGoal => 'Update your daily goal';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -164,7 +164,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'A gente só precisa de alguns detalhes para atualizar seu horário de sono';
 
   @override
-  String get settingsSleepScheduleTitle => 'Atualizar';
+  String get settingsSleepScheduleTitle => 'Horário de Sono';
 
   @override
   String get settingsUnitSystem => 'Sistema de unidades';
@@ -177,7 +177,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'A gente só precisa de alguns detalhes para atualizar sua meta';
 
   @override
-  String get settingsUpdateDailyGoalTitle => 'Atualizar';
+  String get settingsUpdateDailyGoalTitle => 'Meta Diária';
 
   @override
   String get settingsUpdateYourDailyGoal => 'Atualizar meta diária';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -64,11 +64,11 @@
   "settingsSleepSchedule": "Editar horário de sono",
   "settingsSleepScheduleAppBar": "Editar horário de sono",
   "settingsSleepScheduleDescription": "A gente só precisa de alguns detalhes para atualizar seu horário de sono",
-  "settingsSleepScheduleTitle": "Atualizar",
+  "settingsSleepScheduleTitle": "Horário de Sono",
   "settingsUnitSystem": "Sistema de unidades",
   "settingsUpdateDailyGoalAppBar": "Atualizar meta",
   "settingsUpdateDailyGoalDescription": "A gente só precisa de alguns detalhes para atualizar sua meta",
-  "settingsUpdateDailyGoalTitle": "Atualizar",
+  "settingsUpdateDailyGoalTitle": "Meta Diária",
   "settingsUpdateYourDailyGoal": "Atualizar meta diária",
   "settingsYouSection": "Você",
 

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -69,7 +69,7 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
               child: Column(
                 children: [
                   IconHeader(
-                    iconAsset: 'assets/images/water-drop.svg', 
+                    iconAsset: 'assets/images/notifications.svg', 
                     title: AppLocalizations.of(context)!.settingsSleepScheduleTitle, 
                     description: AppLocalizations.of(context)!.settingsSleepScheduleDescription
                   ),

--- a/lib/widgets/setup/setup_step_one.dart
+++ b/lib/widgets/setup/setup_step_one.dart
@@ -19,7 +19,7 @@ class SetupStepOne extends StatelessWidget {
       spacing: 32,
       children: [
         IconHeader(
-          iconAsset: 'assets/images/water-drop.svg', 
+          iconAsset: 'assets/images/notifications.svg', 
           title: AppLocalizations.of(context)!.notificationSetupTitle, 
           description: AppLocalizations.of(context)!.notificationSetupDescription,
         ),


### PR DESCRIPTION
# Description
This pull request adds a new notification image for use in heroes and updates the titles for the Sleep Schedule and Daily Goal settings to better reflect their purpose.

# Changes
- Added new notification image.
- Displayed the notification image in the Notifications settings during setup and on the Sleep Schedule settings page.
- Updated Sleep Schedule settings page title to "Sleep Schedule".
- Updated Daily Goal settings page title to "Daily Goal".