### PR TITLE
feat: add notifications setting for frequency

### DIFF
--- a/lib/data/model/enum/frequency.dart
+++ b/lib/data/model/enum/frequency.dart
@@ -8,4 +8,11 @@ enum Frequency {
 
   const Frequency(this.frequency);
   final int frequency;
+
+  static Frequency getFrequency(int minutes) {
+    return Frequency
+      .values
+      .where((value) => value.frequency == minutes)
+      .first;
+  }
 }

--- a/lib/data/model/enum/frequency.dart
+++ b/lib/data/model/enum/frequency.dart
@@ -1,0 +1,11 @@
+enum Frequency {
+  every15Minutes(15),
+  every30Minutes(30),
+  everyHour(60),
+  every2Hours(120),
+  every3Hours(180),
+  every4Hours(240);
+
+  const Frequency(this.frequency);
+  final int frequency;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,6 +5,7 @@
   "doNotSaveLabel": "Do not save",
   "editAction": "Edit",
   "updateAction": "Update",
+  "manageAction": "Manage",
 
   "bottomNavHomeLabel": "Home",
   "bottomNavSummaryLabel": "Summary",
@@ -58,7 +59,6 @@
   "settingsFeedback": "Send feedback",
   "settingsFeedbackDescription": "Share your thoughts with us",
   "settingsGeneralSection": "General",
-  "settingsNotifications": "Notifications",
   "settingsPageTitle": "Settings",
   "settingsSetCustomDailyGoal": "Set a custom daily goal",
   "settingsSleepSchedule": "Edit sleep schedule",
@@ -71,6 +71,7 @@
   "settingsUpdateDailyGoalTitle": "Daily Goal",
   "settingsUpdateYourDailyGoal": "Update your daily goal",
   "settingsYouSection": "You",
+  "settingsNotificationsSection": "Notifications",
 
   "setupAgeTextFieldInvalidValue": "Age between 10 and 120",
   "setupAgeTextFieldLabel": "Your age",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -101,5 +101,33 @@
   "kgUnit": "kg",
   "lbUnit": "lb",
   "metric": "Metric",
-  "mlUnit": "ml"
+  "mlUnit": "ml",
+
+  "minutes": "{time} minutes",
+  "@minutes": {
+    "placeholders": {
+      "time": {
+        "type": "String",
+        "example": "15"
+      }
+    }
+  },
+  "hour": "{time} hour",
+  "@hour": {
+    "placeholders": {
+      "time": {
+        "type": "String",
+        "example": "1"
+      }
+    }
+  },
+  "hours": "{time} hours",
+  "@hours": {
+    "placeholders": {
+      "time": {
+        "type": "String",
+        "example": "2"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -72,6 +72,8 @@
   "settingsUpdateYourDailyGoal": "Update your daily goal",
   "settingsYouSection": "You",
   "settingsNotificationsSection": "Notifications",
+  "settingsNotificationsManageDescription": "Toggle notifications",
+  "settingsNotificationsSleepScheduleDescription": "Wake/sleep times & frequency",
   "settingsNotificationsFrequency": "Frequency",
 
   "setupAgeTextFieldInvalidValue": "Age between 10 and 120",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -72,6 +72,7 @@
   "settingsUpdateYourDailyGoal": "Update your daily goal",
   "settingsYouSection": "You",
   "settingsNotificationsSection": "Notifications",
+  "settingsNotificationsFrequency": "Frequency",
 
   "setupAgeTextFieldInvalidValue": "Age between 10 and 120",
   "setupAgeTextFieldLabel": "Your age",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -434,6 +434,18 @@ abstract class AppLocalizations {
   /// **'Notifications'**
   String get settingsNotificationsSection;
 
+  /// No description provided for @settingsNotificationsManageDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Toggle notifications'**
+  String get settingsNotificationsManageDescription;
+
+  /// No description provided for @settingsNotificationsSleepScheduleDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Wake/sleep times & frequency'**
+  String get settingsNotificationsSleepScheduleDescription;
+
   /// No description provided for @settingsNotificationsFrequency.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -434,6 +434,12 @@ abstract class AppLocalizations {
   /// **'Notifications'**
   String get settingsNotificationsSection;
 
+  /// No description provided for @settingsNotificationsFrequency.
+  ///
+  /// In en, this message translates to:
+  /// **'Frequency'**
+  String get settingsNotificationsFrequency;
+
   /// No description provided for @setupAgeTextFieldInvalidValue.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -134,6 +134,12 @@ abstract class AppLocalizations {
   /// **'Update'**
   String get updateAction;
 
+  /// No description provided for @manageAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage'**
+  String get manageAction;
+
   /// No description provided for @bottomNavHomeLabel.
   ///
   /// In en, this message translates to:
@@ -350,12 +356,6 @@ abstract class AppLocalizations {
   /// **'General'**
   String get settingsGeneralSection;
 
-  /// No description provided for @settingsNotifications.
-  ///
-  /// In en, this message translates to:
-  /// **'Notifications'**
-  String get settingsNotifications;
-
   /// No description provided for @settingsPageTitle.
   ///
   /// In en, this message translates to:
@@ -427,6 +427,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You'**
   String get settingsYouSection;
+
+  /// No description provided for @settingsNotificationsSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get settingsNotificationsSection;
 
   /// No description provided for @setupAgeTextFieldInvalidValue.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -529,6 +529,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'ml'**
   String get mlUnit;
+
+  /// No description provided for @minutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{time} minutes'**
+  String minutes(String time);
+
+  /// No description provided for @hour.
+  ///
+  /// In en, this message translates to:
+  /// **'{time} hour'**
+  String hour(String time);
+
+  /// No description provided for @hours.
+  ///
+  /// In en, this message translates to:
+  /// **'{time} hours'**
+  String hours(String time);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -186,6 +186,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsNotificationsSection => 'Notifications';
 
   @override
+  String get settingsNotificationsManageDescription => 'Toggle notifications';
+
+  @override
+  String get settingsNotificationsSleepScheduleDescription =>
+      'Wake/sleep times & frequency';
+
+  @override
   String get settingsNotificationsFrequency => 'Frequency';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -235,4 +235,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get mlUnit => 'ml';
+
+  @override
+  String minutes(String time) {
+    return '$time minutes';
+  }
+
+  @override
+  String hour(String time) {
+    return '$time hour';
+  }
+
+  @override
+  String hours(String time) {
+    return '$time hours';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -186,6 +186,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsNotificationsSection => 'Notifications';
 
   @override
+  String get settingsNotificationsFrequency => 'Frequency';
+
+  @override
   String get setupAgeTextFieldInvalidValue => 'Age between 10 and 120';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -27,6 +27,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateAction => 'Update';
 
   @override
+  String get manageAction => 'Manage';
+
+  @override
   String get bottomNavHomeLabel => 'Home';
 
   @override
@@ -142,9 +145,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsGeneralSection => 'General';
 
   @override
-  String get settingsNotifications => 'Notifications';
-
-  @override
   String get settingsPageTitle => 'Settings';
 
   @override
@@ -181,6 +181,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsYouSection => 'You';
+
+  @override
+  String get settingsNotificationsSection => 'Notifications';
 
   @override
   String get setupAgeTextFieldInvalidValue => 'Age between 10 and 120';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -27,6 +27,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateAction => 'Atualizar';
 
   @override
+  String get manageAction => 'Manage';
+
+  @override
   String get bottomNavHomeLabel => 'Home';
 
   @override
@@ -145,9 +148,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsGeneralSection => 'Geral';
 
   @override
-  String get settingsNotifications => 'Notificações';
-
-  @override
   String get settingsPageTitle => 'Configurações';
 
   @override
@@ -184,6 +184,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsYouSection => 'Você';
+
+  @override
+  String get settingsNotificationsSection => 'Notifications';
 
   @override
   String get setupAgeTextFieldInvalidValue => 'Idade entre 10 e 120';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -189,6 +189,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsNotificationsSection => 'Notifications';
 
   @override
+  String get settingsNotificationsFrequency => 'Frequency';
+
+  @override
   String get setupAgeTextFieldInvalidValue => 'Idade entre 10 e 120';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -189,6 +189,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsNotificationsSection => 'Notifications';
 
   @override
+  String get settingsNotificationsManageDescription => 'Toggle notifications';
+
+  @override
+  String get settingsNotificationsSleepScheduleDescription =>
+      'Wake/sleep times & frequency';
+
+  @override
   String get settingsNotificationsFrequency => 'Frequency';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -238,4 +238,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get mlUnit => 'ml';
+
+  @override
+  String minutes(String time) {
+    return '$time minutes';
+  }
+
+  @override
+  String hour(String time) {
+    return '$time hour';
+  }
+
+  @override
+  String hours(String time) {
+    return '$time hours';
+  }
 }

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -13,16 +13,31 @@ class SettingsFrequencyPage extends StatefulWidget {
 }
 
 class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
-  Frequency frequency = Frequency.every2Hours;
+  Frequency? frequency;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final loadedFrequency = await _loadFrequency();
+
+      setState(() {
+        frequency = loadedFrequency;
+      });
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final provider = context.read<SettingsProvider>();
+
+    if(frequency == null) {
+      return Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -104,8 +119,23 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
       frequency = newFrequency!;
     });
 
-    context.read<SettingsProvider>().updateFrequency(
+    provider.updateFrequency(
       newFrequency!.frequency
     );
+  }
+
+  Future<Frequency> _loadFrequency() async {
+    int frequencyValue = await _getFrequency();
+
+    return Frequency
+      .values
+      .where((value) => frequencyValue == value.frequency)
+      .first;
+  }
+
+  Future<int> _getFrequency() async {
+    final provider = context.read<SettingsProvider>();
+    await provider.readFrequency();
+    return provider.frequency!;
   }
 }

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/provider/settings_provider.dart';
+import 'package:hidroly/services/notification_service.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:provider/provider.dart';
 
@@ -115,12 +116,20 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
   }
 
   void _updateRadioValue(Frequency? newFrequency, SettingsProvider provider) {
+    int frequencyValue = newFrequency!.frequency;
+
     setState(() {
-      frequency = newFrequency!;
+      frequency = newFrequency;
     });
 
     provider.updateFrequency(
-      newFrequency!.frequency
+      frequencyValue
+    );
+
+    NotificationService().registerPeriodicNotificationTask(
+      context, 
+      provider,
+      minutes: frequencyValue,
     );
   }
 

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -117,11 +117,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
 
   Future<Frequency> _loadFrequency() async {
     int frequencyValue = await _getFrequency();
-
-    return Frequency
-      .values
-      .where((value) => frequencyValue == value.frequency)
-      .first;
+    return Frequency.getFrequency(frequencyValue);
   }
 
   Future<int> _getFrequency() async {

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -125,12 +125,6 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
     provider.updateFrequency(
       frequencyValue
     );
-
-    NotificationService().registerPeriodicNotificationTask(
-      context, 
-      provider,
-      minutes: frequencyValue,
-    );
   }
 
   Future<Frequency> _loadFrequency() async {

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -2,20 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/provider/settings_provider.dart';
-import 'package:hidroly/services/notification_service.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:provider/provider.dart';
 
 class SettingsFrequencyPage extends StatefulWidget {
-  const SettingsFrequencyPage({super.key});
+  final ValueNotifier<Frequency> frequency;
+
+  const SettingsFrequencyPage({
+    super.key,
+    required this.frequency,
+  });
 
   @override
   State<SettingsFrequencyPage> createState() => _SettingsFrequencyPageState();
 }
 
 class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
-  Frequency? frequency;
-
   @override
   void initState() {
     super.initState();
@@ -23,7 +25,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
       final loadedFrequency = await _loadFrequency();
 
       setState(() {
-        frequency = loadedFrequency;
+        widget.frequency.value = loadedFrequency;
       });
     });
   }
@@ -32,7 +34,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
   Widget build(BuildContext context) {
     final provider = context.read<SettingsProvider>();
 
-    if(frequency == null) {
+    if(widget.frequency.value == null) {
       return Scaffold(
         body: Center(
           child: CircularProgressIndicator(),
@@ -62,7 +64,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every15Minutes, 
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
           RadioListTile(
@@ -71,7 +73,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every30Minutes, 
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
           RadioListTile(
@@ -80,7 +82,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.everyHour, 
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
           RadioListTile(
@@ -89,7 +91,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every2Hours, 
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
           RadioListTile(
@@ -98,7 +100,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every3Hours, 
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
           RadioListTile(
@@ -107,7 +109,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every4Hours,
-            groupValue: frequency,
+            groupValue: widget.frequency.value,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),
         ],
@@ -116,15 +118,9 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
   }
 
   void _updateRadioValue(Frequency? newFrequency, SettingsProvider provider) {
-    int frequencyValue = newFrequency!.frequency;
-
     setState(() {
-      frequency = newFrequency;
+      widget.frequency.value = newFrequency!;
     });
-
-    provider.updateFrequency(
-      frequencyValue
-    );
   }
 
   Future<Frequency> _loadFrequency() async {

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -42,7 +42,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
         children: [
           RadioListTile(
             title: Text(
-              '15 minutes',
+              AppLocalizations.of(context)!.minutes('15'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every15Minutes, 
@@ -51,7 +51,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
           ),
           RadioListTile(
             title: Text(
-              '30 minutes',
+              AppLocalizations.of(context)!.minutes('30'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every30Minutes, 
@@ -60,7 +60,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
           ),
           RadioListTile(
             title: Text(
-              '1 hour',
+              AppLocalizations.of(context)!.hour('1'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.everyHour, 
@@ -69,7 +69,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
           ),
           RadioListTile(
             title: Text(
-              '2 hours',
+              AppLocalizations.of(context)!.hours('2'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every2Hours, 
@@ -78,7 +78,7 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
           ),
           RadioListTile(
             title: Text(
-              '3 hours',
+              AppLocalizations.of(context)!.hours('3'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             value: Frequency.every3Hours, 
@@ -87,10 +87,10 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
           ),
           RadioListTile(
             title: Text(
-              '4 hours',
+              AppLocalizations.of(context)!.hours('4'),
               style: Theme.of(context).textTheme.bodyLarge,
             ),
-            value: Frequency.every4Hours, 
+            value: Frequency.every4Hours,
             groupValue: frequency,
             onChanged: (val) => _updateRadioValue(val, provider),
           ),

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
+import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/provider/settings_provider.dart';
+import 'package:hidroly/theme/app_colors.dart';
+import 'package:provider/provider.dart';
+
+class SettingsFrequencyPage extends StatefulWidget {
+  const SettingsFrequencyPage({super.key});
+
+  @override
+  State<SettingsFrequencyPage> createState() => _SettingsFrequencyPageState();
+}
+
+class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
+  Frequency frequency = Frequency.every2Hours;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.read<SettingsProvider>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.settingsNotificationsFrequency),
+        leading: IconButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          }, 
+          icon: Icon(
+            Icons.arrow_back,
+            color: AppColors.primaryText,
+          ),
+        ),
+        titleSpacing: 0,
+      ),
+      body: Column(
+        children: [
+          RadioListTile(
+            title: Text(
+              '15 minutes',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.every15Minutes, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+          RadioListTile(
+            title: Text(
+              '30 minutes',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.every30Minutes, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+          RadioListTile(
+            title: Text(
+              '1 hour',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.everyHour, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+          RadioListTile(
+            title: Text(
+              '2 hours',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.every2Hours, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+          RadioListTile(
+            title: Text(
+              '3 hours',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.every3Hours, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+          RadioListTile(
+            title: Text(
+              '4 hours',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            value: Frequency.every4Hours, 
+            groupValue: frequency,
+            onChanged: (val) => _updateRadioValue(val, provider),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _updateRadioValue(Frequency? newFrequency, SettingsProvider provider) {
+    setState(() {
+      frequency = newFrequency!;
+    });
+
+    context.read<SettingsProvider>().updateFrequency(
+      newFrequency!.frequency
+    );
+  }
+}

--- a/lib/pages/settings/settings_frequency_page.dart
+++ b/lib/pages/settings/settings_frequency_page.dart
@@ -34,14 +34,6 @@ class _SettingsFrequencyPageState extends State<SettingsFrequencyPage> {
   Widget build(BuildContext context) {
     final provider = context.read<SettingsProvider>();
 
-    if(widget.frequency.value == null) {
-      return Scaffold(
-        body: Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
-    }
-
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.settingsNotificationsFrequency),

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -17,6 +17,8 @@ class SettingsUpdateSleepSchedulePage extends StatefulWidget {
 }
 
 class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSchedulePage> {
+  bool isLoading = true;
+
   var wakeUpTime = ValueNotifier(
     TimeOfDay(hour: 6, minute: 0)
   );
@@ -48,12 +50,21 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
         wakeUpTime.value = provider.wakeUpTime!;
         sleepTime.value = provider.sleepTime!;
         frequency.value = Frequency.getFrequency(provider.frequency!);
+        isLoading = false;
       });
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    if(isLoading) {
+      return Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.settingsSleepScheduleAppBar),

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -41,11 +41,13 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
     final provider = context.read<SettingsProvider>();
     await provider.readTime(Settings.wakeUpTime);
     await provider.readTime(Settings.sleepTime);
+    await provider.readFrequency();
 
-    if(provider.wakeUpTime != null && provider.sleepTime != null) {
+    if(provider.wakeUpTime != null && provider.sleepTime != null && provider.frequency != null) {
       setState(() {
         wakeUpTime.value = provider.wakeUpTime!;
         sleepTime.value = provider.sleepTime!;
+        frequency.value = _getCurrentFrequency(provider.frequency!);
       });
     }
   }
@@ -132,5 +134,12 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
         child: Icon(Icons.done), 
       ),
     );
+  }
+
+  Frequency _getCurrentFrequency(int frequency) {
+    return Frequency
+      .values
+      .where((value) => frequency == value.frequency)
+      .first;
   }
 }

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -106,10 +106,13 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
             sleepTime.value.minute,
           );
 
+          await settingsProvider.updateFrequency(frequency.value.frequency);
+
           if(!context.mounted) return;
           final saved = await NotificationService().registerPeriodicNotificationTask(
             context, 
             settingsProvider,
+            minutes: frequency.value.frequency,
           );
 
           if(!saved && context.mounted) {

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -103,7 +103,7 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
           if(!context.mounted) return;
           final saved = await NotificationService().registerPeriodicNotificationTask(
             context, 
-            settingsProvider
+            settingsProvider,
           );
 
           if(!saved && context.mounted) {

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/data/model/enum/settings.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/provider/settings_provider.dart';
@@ -22,6 +23,10 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
 
   var sleepTime = ValueNotifier(
     TimeOfDay(hour: 22, minute: 0)
+  );
+
+  var frequency = ValueNotifier(
+    Frequency.every2Hours
   );
 
   @override
@@ -76,7 +81,8 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
                   SizedBox(height: 32,),
                   NotificationsTimeInput(
                     wakeUpTime: wakeUpTime, 
-                    sleepTime: sleepTime
+                    sleepTime: sleepTime,
+                    frequency: frequency,
                   )
                 ],
               ),

--- a/lib/pages/settings/settings_update_sleep_schedule_page.dart
+++ b/lib/pages/settings/settings_update_sleep_schedule_page.dart
@@ -47,7 +47,7 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
       setState(() {
         wakeUpTime.value = provider.wakeUpTime!;
         sleepTime.value = provider.sleepTime!;
-        frequency.value = _getCurrentFrequency(provider.frequency!);
+        frequency.value = Frequency.getFrequency(provider.frequency!);
       });
     }
   }
@@ -134,12 +134,5 @@ class _SettingsUpdateSleepSchedulePageState extends State<SettingsUpdateSleepSch
         child: Icon(Icons.done), 
       ),
     );
-  }
-
-  Frequency _getCurrentFrequency(int frequency) {
-    return Frequency
-      .values
-      .where((value) => frequency == value.frequency)
-      .first;
   }
 }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -52,11 +52,11 @@ class _SettingsPageState extends State<SettingsPage> {
                   isMetric: isMetric,
                 ),
                 SizedBox(height: 16,),
-                SettingsNotifications(),
-                SizedBox(height: 16,),
                 SettingsYou(
                   isMetric: isMetric
                 ),
+                SizedBox(height: 16,),
+                SettingsNotifications(),
                 SizedBox(height: 16,),
                 SettingsAbout(),
               ],

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -53,6 +53,8 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
                 SettingsNotifications(),
                 SizedBox(height: 16,),
+                SettingsNotifications(),
+                SizedBox(height: 16,),
                 SettingsYou(
                   isMetric: isMetric
                 ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/widgets/settings/sections/settings_about.dart';
 import 'package:hidroly/widgets/settings/sections/settings_general.dart';
+import 'package:hidroly/widgets/settings/sections/settings_notifications.dart';
 import 'package:hidroly/widgets/settings/sections/settings_you.dart';
 import 'package:hidroly/provider/settings_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
@@ -50,6 +51,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 SettingsGeneral(
                   isMetric: isMetric,
                 ),
+                SettingsNotifications(),
                 SizedBox(height: 16,),
                 SettingsYou(
                   isMetric: isMetric

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -51,7 +51,6 @@ class _SettingsPageState extends State<SettingsPage> {
                 SettingsGeneral(
                   isMetric: isMetric,
                 ),
-                SettingsNotifications(),
                 SizedBox(height: 16,),
                 SettingsNotifications(),
                 SizedBox(height: 16,),

--- a/lib/pages/setup_page.dart
+++ b/lib/pages/setup_page.dart
@@ -103,7 +103,8 @@ class _SetupPageState extends State<SetupPage> {
           if(!context.mounted) return;
           final notificationTaskCreated = await NotificationService().registerPeriodicNotificationTask(
             context,
-            settingsProvider
+            settingsProvider,
+            minutes: frequency.value.frequency,
           );
 
           if(!notificationTaskCreated && context.mounted) {
@@ -158,6 +159,8 @@ class _SetupPageState extends State<SetupPage> {
       sleepTime.value.hour, 
       sleepTime.value.minute
     );
+
+    await settingsProvider.updateFrequency(frequency.value.frequency);
   }
 
   Future<bool> _createDay(BuildContext context, int dailyGoal) async {

--- a/lib/pages/setup_page.dart
+++ b/lib/pages/setup_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/data/model/enum/settings.dart';
 import 'package:hidroly/data/model/water_button.dart';
 import 'package:hidroly/provider/custom_cups_provider.dart';
@@ -32,6 +33,7 @@ class _SetupPageState extends State<SetupPage> {
   final ValueNotifier<bool> isMetric = ValueNotifier(true);
   final wakeUpTime = ValueNotifier(TimeOfDay(hour: 6, minute: 0));
   final sleepTime = ValueNotifier(TimeOfDay(hour: 22, minute: 0));
+  final frequency = ValueNotifier(Frequency.every2Hours);
 
   int setupStep = 0;
 
@@ -61,7 +63,8 @@ class _SetupPageState extends State<SetupPage> {
                 )
                 : SetupStepOne(
                   wakeUpTime: wakeUpTime, 
-                  sleepTime: sleepTime
+                  sleepTime: sleepTime,
+                  frequency: frequency,
                 ),
             ),
           ),

--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/data/model/enum/settings.dart';
 import 'package:hidroly/utils/app_date_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,6 +8,7 @@ class SettingsProvider extends ChangeNotifier {
   final _asyncPrefs = SharedPreferencesAsync();
 
   bool? isMetric;
+  int? frequency;
   TimeOfDay? wakeUpTime;
   TimeOfDay? sleepTime;
 
@@ -18,6 +20,18 @@ class SettingsProvider extends ChangeNotifier {
 
   Future<void> readIsMetric() async {
     isMetric = await _asyncPrefs.getBool('isMetric') ?? true;
+    notifyListeners();
+  }
+
+  Future<void> updateFrequency(int value) async {
+    await _asyncPrefs.setInt('frequency', value);
+    frequency = value;
+    notifyListeners();
+  }
+
+  Future<void> readFrequency() async {
+    final defaultFrequency = Frequency.every2Hours;
+    frequency = await _asyncPrefs.getInt('frequency') ?? defaultFrequency.frequency;
     notifyListeners();
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -51,7 +51,8 @@ class NotificationService {
 
   Future<bool> registerPeriodicNotificationTask(
     BuildContext context, 
-    SettingsProvider settingsProvider
+    SettingsProvider settingsProvider,
+    {int minutes = 120}
   ) async {
     if(settingsProvider.wakeUpTime == null || settingsProvider.sleepTime == null) {
       return false;
@@ -75,7 +76,7 @@ class NotificationService {
     await workManager.registerPeriodicTask(
       'notification',
       'notificationTask',
-      frequency: Duration(hours: 1),
+      frequency: Duration(minutes: minutes),
       inputData: {
         Settings.wakeUpTime.value: formattedWakeUpTime,
         Settings.sleepTime.value: formattedSleepTime,

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -3,17 +3,19 @@ import 'package:hidroly/l10n/app_localizations.dart';
 
 class TimeUtils {
   static String getTimeString(int minutes, BuildContext context) {
+    int hours = minutes ~/ 60;
+
     if(minutes < 60) {
       return AppLocalizations.of(context)!.minutes(
         minutes.toString()
       );
     } else if(minutes < 120) {
       return AppLocalizations.of(context)!.hour(
-        minutes.toString()
+        hours.toString()
       );
     } else {
       return AppLocalizations.of(context)!.hours(
-        minutes.toString()
+        hours.toString()
       );
     }
   }

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+import 'package:hidroly/l10n/app_localizations.dart';
+
+class TimeUtils {
+  static String getTimeString(int minutes, BuildContext context) {
+    if(minutes < 60) {
+      return AppLocalizations.of(context)!.minutes(
+        minutes.toString()
+      );
+    } else if(minutes < 120) {
+      return AppLocalizations.of(context)!.hour(
+        minutes.toString()
+      );
+    } else {
+      return AppLocalizations.of(context)!.hours(
+        minutes.toString()
+      );
+    }
+  }
+}

--- a/lib/widgets/common/notifications_time_input.dart
+++ b/lib/widgets/common/notifications_time_input.dart
@@ -91,9 +91,13 @@ class _NotificationsTimeInputState extends State<NotificationsTimeInput> {
             trailing: Icon(Icons.arrow_forward),
             iconColor: AppColors.primaryText,
             onTap: () async {
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
+              await Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => SettingsFrequencyPage(frequency: widget.frequency,)),
               );
+
+              setState(() {
+                widget.frequency.value;
+              });       
             },
           ),
         ],

--- a/lib/widgets/common/notifications_time_input.dart
+++ b/lib/widgets/common/notifications_time_input.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/pages/settings/settings_frequency_page.dart';
 import 'package:hidroly/theme/app_colors.dart';
+import 'package:hidroly/utils/time_utils.dart';
 
 class NotificationsTimeInput extends StatefulWidget {
   final ValueNotifier<TimeOfDay> wakeUpTime;
   final ValueNotifier<TimeOfDay> sleepTime;
+  final ValueNotifier<Frequency> frequency;
 
   const NotificationsTimeInput({
     super.key,
     required this.wakeUpTime,
     required this.sleepTime,
+    required this.frequency,
   });
 
   @override
@@ -71,6 +76,24 @@ class _NotificationsTimeInputState extends State<NotificationsTimeInput> {
                   widget.sleepTime.value = newTime;
                 });
               }
+            },
+          ),
+          ListTile(
+            leading: Icon(Icons.schedule),
+            title: Text(
+              AppLocalizations.of(context)!.settingsNotificationsFrequency,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            subtitle: Text(
+             TimeUtils.getTimeString(widget.frequency.value.frequency, context),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            trailing: Icon(Icons.arrow_forward),
+            iconColor: AppColors.primaryText,
+            onTap: () async {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
+              );
             },
           ),
         ],

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -1,15 +1,12 @@
+import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
-import 'package:hidroly/pages/settings/settings_unit_page.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/settings/settings_text_button.dart';
 
-class SettingsGeneral extends StatelessWidget {
-  final bool isMetric;
-
-  const SettingsGeneral({
+class SettingsNotifications extends StatelessWidget {
+  const SettingsNotifications({
     super.key,
-    required this.isMetric,
   });
 
   @override
@@ -18,20 +15,17 @@ class SettingsGeneral extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          AppLocalizations.of(context)!.settingsGeneralSection,
+          AppLocalizations.of(context)!.settingsNotificationsSection,
           style: TextStyle(
             color: AppColors.primaryText,
             fontWeight: FontWeight.bold,
           ),
         ),
         SettingsTextButton(
-          title: AppLocalizations.of(context)!.settingsUnitSystem,
-          description: isMetric
-              ? AppLocalizations.of(context)!.metric
-              : AppLocalizations.of(context)!.imperial,
+          title: AppLocalizations.of(context)!.manageAction,
           onPressed: () async {
-            await Navigator.of(context).push(
-              MaterialPageRoute(builder: (context) => const SettingsUnitPage()),
+            AppSettings.openAppSettings(
+              type: AppSettingsType.notification,
             );
           },
         ),

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -29,6 +29,7 @@ class _SettingsNotificationsState extends State<SettingsNotifications> {
         ),
         SettingsTextButton(
           title: AppLocalizations.of(context)!.manageAction,
+          description: AppLocalizations.of(context)!.settingsNotificationsManageDescription,
           onPressed: () async {
             AppSettings.openAppSettings(
               type: AppSettingsType.notification,
@@ -37,6 +38,7 @@ class _SettingsNotificationsState extends State<SettingsNotifications> {
         ),
         SettingsTextButton(
           title: AppLocalizations.of(context)!.settingsSleepSchedule,
+          description: AppLocalizations.of(context)!.settingsNotificationsSleepScheduleDescription,
           onPressed: () {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -1,6 +1,7 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/pages/settings/settings_update_sleep_schedule_page.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/widgets/settings/settings_text_button.dart';
 
@@ -28,6 +29,14 @@ class SettingsNotifications extends StatelessWidget {
               type: AppSettingsType.notification,
             );
           },
+        ),
+        SettingsTextButton(
+          title: AppLocalizations.of(context)!.settingsSleepSchedule,
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
+            );
+          }
         ),
       ],
     );

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -32,42 +32,46 @@ class _SettingsNotificationsState extends State<SettingsNotifications> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          AppLocalizations.of(context)!.settingsNotificationsSection,
-          style: TextStyle(
-            color: AppColors.primaryText,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        SettingsTextButton(
-          title: AppLocalizations.of(context)!.manageAction,
-          onPressed: () async {
-            AppSettings.openAppSettings(
-              type: AppSettingsType.notification,
-            );
-          },
-        ),
-        SettingsTextButton(
-          title: AppLocalizations.of(context)!.settingsNotificationsFrequency,
-          description: TimeUtils.getTimeString(frequency, context),
-          onPressed: () async {
-            Navigator.of(context).push(
-              MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
-            );
-          },
-        ),
-        SettingsTextButton(
-          title: AppLocalizations.of(context)!.settingsSleepSchedule,
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
-            );
-          }
-        ),
-      ],
+    return Consumer<SettingsProvider>(
+      builder: (context, provider, child) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              AppLocalizations.of(context)!.settingsNotificationsSection,
+              style: TextStyle(
+                color: AppColors.primaryText,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            SettingsTextButton(
+              title: AppLocalizations.of(context)!.manageAction,
+              onPressed: () async {
+                AppSettings.openAppSettings(
+                  type: AppSettingsType.notification,
+                );
+              },
+            ),
+            SettingsTextButton(
+              title: AppLocalizations.of(context)!.settingsNotificationsFrequency,
+              description: TimeUtils.getTimeString(provider.frequency!, context),
+              onPressed: () async {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
+                );
+              },
+            ),
+            SettingsTextButton(
+              title: AppLocalizations.of(context)!.settingsSleepSchedule,
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
+                );
+              }
+            ),
+          ],
+        );
+      }
     );
   }
 

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -1,16 +1,34 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/pages/settings/settings_frequency_page.dart';
 import 'package:hidroly/pages/settings/settings_update_sleep_schedule_page.dart';
+import 'package:hidroly/provider/settings_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
-import 'package:hidroly/widgets/input/number_input_dialog.dart';
+import 'package:hidroly/utils/time_utils.dart';
 import 'package:hidroly/widgets/settings/settings_text_button.dart';
+import 'package:provider/provider.dart';
 
-class SettingsNotifications extends StatelessWidget {
+class SettingsNotifications extends StatefulWidget {
   const SettingsNotifications({
     super.key,
   });
+
+  @override
+  State<SettingsNotifications> createState() => _SettingsNotificationsState();
+}
+
+class _SettingsNotificationsState extends State<SettingsNotifications> {
+  int frequency = Frequency.every2Hours.frequency;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      frequency = await _loadFrequency();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +52,7 @@ class SettingsNotifications extends StatelessWidget {
         ),
         SettingsTextButton(
           title: AppLocalizations.of(context)!.settingsNotificationsFrequency,
-          description: "2 hours",
+          description: TimeUtils.getTimeString(frequency, context),
           onPressed: () async {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
@@ -51,5 +69,11 @@ class SettingsNotifications extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  Future<int> _loadFrequency() async {
+    final provider = context.read<SettingsProvider>();
+    await provider.readFrequency();
+    return provider.frequency!;
   }
 }

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -1,8 +1,10 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/pages/settings/settings_frequency_page.dart';
 import 'package:hidroly/pages/settings/settings_update_sleep_schedule_page.dart';
 import 'package:hidroly/theme/app_colors.dart';
+import 'package:hidroly/widgets/input/number_input_dialog.dart';
 import 'package:hidroly/widgets/settings/settings_text_button.dart';
 
 class SettingsNotifications extends StatelessWidget {
@@ -27,6 +29,15 @@ class SettingsNotifications extends StatelessWidget {
           onPressed: () async {
             AppSettings.openAppSettings(
               type: AppSettingsType.notification,
+            );
+          },
+        ),
+        SettingsTextButton(
+          title: AppLocalizations.of(context)!.settingsNotificationsFrequency,
+          description: "2 hours",
+          onPressed: () async {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
             );
           },
         ),

--- a/lib/widgets/settings/sections/settings_notifications.dart
+++ b/lib/widgets/settings/sections/settings_notifications.dart
@@ -1,14 +1,9 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
-import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
-import 'package:hidroly/pages/settings/settings_frequency_page.dart';
 import 'package:hidroly/pages/settings/settings_update_sleep_schedule_page.dart';
-import 'package:hidroly/provider/settings_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
-import 'package:hidroly/utils/time_utils.dart';
 import 'package:hidroly/widgets/settings/settings_text_button.dart';
-import 'package:provider/provider.dart';
 
 class SettingsNotifications extends StatefulWidget {
   const SettingsNotifications({
@@ -20,64 +15,35 @@ class SettingsNotifications extends StatefulWidget {
 }
 
 class _SettingsNotificationsState extends State<SettingsNotifications> {
-  int frequency = Frequency.every2Hours.frequency;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      frequency = await _loadFrequency();
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Consumer<SettingsProvider>(
-      builder: (context, provider, child) {
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              AppLocalizations.of(context)!.settingsNotificationsSection,
-              style: TextStyle(
-                color: AppColors.primaryText,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SettingsTextButton(
-              title: AppLocalizations.of(context)!.manageAction,
-              onPressed: () async {
-                AppSettings.openAppSettings(
-                  type: AppSettingsType.notification,
-                );
-              },
-            ),
-            SettingsTextButton(
-              title: AppLocalizations.of(context)!.settingsNotificationsFrequency,
-              description: TimeUtils.getTimeString(provider.frequency!, context),
-              onPressed: () async {
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const SettingsFrequencyPage()),
-                );
-              },
-            ),
-            SettingsTextButton(
-              title: AppLocalizations.of(context)!.settingsSleepSchedule,
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
-                );
-              }
-            ),
-          ],
-        );
-      }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          AppLocalizations.of(context)!.settingsNotificationsSection,
+          style: TextStyle(
+            color: AppColors.primaryText,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        SettingsTextButton(
+          title: AppLocalizations.of(context)!.manageAction,
+          onPressed: () async {
+            AppSettings.openAppSettings(
+              type: AppSettingsType.notification,
+            );
+          },
+        ),
+        SettingsTextButton(
+          title: AppLocalizations.of(context)!.settingsSleepSchedule,
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
+            );
+          }
+        ),
+      ],
     );
-  }
-
-  Future<int> _loadFrequency() async {
-    final provider = context.read<SettingsProvider>();
-    await provider.readFrequency();
-    return provider.frequency!;
   }
 }

--- a/lib/widgets/settings/sections/settings_you.dart
+++ b/lib/widgets/settings/sections/settings_you.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hidroly/data/model/day.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/pages/settings/settings_update_daily_goal_page.dart';
-import 'package:hidroly/pages/settings/settings_update_sleep_schedule_page.dart';
 import 'package:hidroly/provider/day_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/utils/unit_tools.dart';
@@ -71,14 +70,6 @@ class _SettingsYouState extends State<SettingsYou> {
         SettingsTextButton(
           title: AppLocalizations.of(context)!.settingsSetCustomDailyGoal,
           onPressed: () => _showCustomDailyGoalDialog(provider, day),
-        ),
-        SettingsTextButton(
-          title: AppLocalizations.of(context)!.settingsSleepSchedule,
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(builder: (context) => const SettingsUpdateSleepSchedulePage())
-            );
-          }
         ),
       ],
     );

--- a/lib/widgets/setup/setup_step_one.dart
+++ b/lib/widgets/setup/setup_step_one.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hidroly/data/model/enum/frequency.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
 import 'package:hidroly/widgets/common/icon_header.dart';
 import 'package:hidroly/widgets/common/notifications_time_input.dart';
@@ -8,10 +9,12 @@ class SetupStepOne extends StatelessWidget {
     super.key,
     required this.wakeUpTime,
     required this.sleepTime,
+    required this.frequency,
   });
 
   final ValueNotifier<TimeOfDay> wakeUpTime;
   final ValueNotifier<TimeOfDay> sleepTime;
+  final ValueNotifier<Frequency> frequency;
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +29,7 @@ class SetupStepOne extends StatelessWidget {
         NotificationsTimeInput(
           wakeUpTime: wakeUpTime,
           sleepTime: sleepTime,
+          frequency: frequency,
         )
       ],
     );


### PR DESCRIPTION
# Description
This PR introduces a dedicated **Notifications** section in the settings page and adds the ability to configure notification frequency.

# Changes
- Moved notification settings into their own dedicated section.
- Added a setting to customize notification frequency (minimum: 15 minutes, maximum: 4 hours).

# Translation Changes
- Added new time-related keys: `minutes`, `hour`, and `hours`.
- Added new action key: `manageAction`.
- Added 4 new settings keys: 
  - `settingsNotificationsSection`
  - `settingsNotificationsFrequency`
  - `settingsNotificationsManageDescription`
  - `settingsNotificationsSleepScheduleDescription`
- Removed key: `settingsNotifications`.