### PR TITLE
feat: rearrange cups

### DIFF
--- a/lib/config/providers.dart
+++ b/lib/config/providers.dart
@@ -5,6 +5,7 @@ import 'package:hidroly/data/datasource/day_local_datasource_impl.dart';
 import 'package:hidroly/data/repository/custom_cups_repository.dart';
 import 'package:hidroly/data/repository/daily_history_repository.dart';
 import 'package:hidroly/data/repository/day_repository.dart';
+import 'package:hidroly/provider/app_state_provider.dart';
 import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
@@ -16,6 +17,7 @@ final class Providers {
   final providers = <SingleChildWidget>[
     Provider(create: (_) => DatabaseHelper()),
     ChangeNotifierProvider(create: (_) => SettingsProvider()),
+    ChangeNotifierProvider(create: (_) => AppStateProvider()),
 
     // Data Sources
     ProxyProvider<DatabaseHelper, DayLocalDataSourceImpl>(

--- a/lib/controllers/setup_controller.dart
+++ b/lib/controllers/setup_controller.dart
@@ -29,9 +29,9 @@ class SetupController {
 
   Future<bool> createDefaultCups() async {
     final defaultCups = [
-      WaterButton(amount: 250),
-      WaterButton(amount: 300),
-      WaterButton(amount: 600),
+      WaterButton(amount: 250, position: 0),
+      WaterButton(amount: 300, position: 1),
+      WaterButton(amount: 600, position: 2),
     ];
 
     try {

--- a/lib/data/database/database_helper.dart
+++ b/lib/data/database/database_helper.dart
@@ -32,7 +32,7 @@ class DatabaseHelper {
           CREATE TABLE ${DBConstants.customCupsTable} (
             id INTEGER PRIMARY KEY AUTOINCREMENT, 
             amount INTEGER NOT NULL,
-            position INTEGER NOT NULL,
+            position INTEGER NOT NULL
           )
           '''
         );

--- a/lib/data/database/database_helper.dart
+++ b/lib/data/database/database_helper.dart
@@ -31,7 +31,8 @@ class DatabaseHelper {
           '''
           CREATE TABLE ${DBConstants.customCupsTable} (
             id INTEGER PRIMARY KEY AUTOINCREMENT, 
-            amount INTEGER NOT NULL
+            amount INTEGER NOT NULL,
+            position INTEGER NOT NULL,
           )
           '''
         );
@@ -50,7 +51,23 @@ class DatabaseHelper {
       onConfigure: (db) async {
         await db.execute('PRAGMA foreign_keys = ON');
       },
-      version: 2,
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if(oldVersion < 3) {
+          await db.execute(
+            '''
+            ALTER TABLE ${DBConstants.customCupsTable}
+            ADD COLUMN position INTEGER DEFAULT 0 NOT NULL
+            '''
+          );
+          await db.execute(
+            '''
+            UPDATE ${DBConstants.customCupsTable}
+            SET position = rowid
+            '''
+          );
+        }
+      },
+      version: 3,
     );
   }
 }

--- a/lib/data/datasource/custom_cups_local_datasource_impl.dart
+++ b/lib/data/datasource/custom_cups_local_datasource_impl.dart
@@ -27,8 +27,8 @@ class CustomCupsLocalDataSourceImpl implements CustomCupsLocalDataSource {
     );
 
     return [
-      for(final { 'id': id as int, 'amount': amount as int } in customCups)
-        WaterButton(id: id, amount: amount),
+      for(final { 'id': id as int, 'amount': amount as int, 'position': position as int, } in customCups)
+        WaterButton(id: id, amount: amount, position: position),
     ];
   }
 

--- a/lib/data/model/water_button.dart
+++ b/lib/data/model/water_button.dart
@@ -1,25 +1,33 @@
 class WaterButton {
   final int? id;
   final int amount;
+  final int? position;
 
   const WaterButton({
     this.id,
     required this.amount,
+    this.position,
   });
 
   Map<String, Object?> toMap() {
     final map = {'amount': amount};
+    
     if(id != null) {
       map['id'] = id as int;
+    }
+
+    if(position != null) {
+      map['position'] = position as int;
     }
 
     return map;
   }
 
-  WaterButton copyWith({int? id, int? amount}) {
+  WaterButton copyWith({int? id, int? amount, int? position}) {
     return WaterButton(
       id: id ?? this.id,
       amount: amount ?? this.amount,
+      position: position ?? this.position,
     );
   }
 }

--- a/lib/data/model/water_button.dart
+++ b/lib/data/model/water_button.dart
@@ -19,7 +19,7 @@ class WaterButton {
     if(position != null) {
       map['position'] = position as int;
     }
-
+    
     return map;
   }
 
@@ -29,5 +29,10 @@ class WaterButton {
       amount: amount ?? this.amount,
       position: position ?? this.position,
     );
+  }
+
+  @override
+  String toString() {
+    return '$id : $amount : $position';
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
   "deleteAction": "Delete",
   "doNotSaveLabel": "Do not save",
   "editAction": "Edit",
+  "rearrangeAction": "Rearrange",
   "updateAction": "Update",
   "manageAction": "Manage",
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -130,6 +130,12 @@ abstract class AppLocalizations {
   /// **'Edit'**
   String get editAction;
 
+  /// No description provided for @rearrangeAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Rearrange'**
+  String get rearrangeAction;
+
   /// No description provided for @updateAction.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -24,6 +24,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editAction => 'Bearbeiten';
 
   @override
+  String get rearrangeAction => 'Rearrange';
+
+  @override
   String get updateAction => 'Aktualisieren';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -24,6 +24,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editAction => 'Edit';
 
   @override
+  String get rearrangeAction => 'Rearrange';
+
+  @override
   String get updateAction => 'Update';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -24,6 +24,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get editAction => 'Editar';
 
   @override
+  String get rearrangeAction => 'Reorganizar';
+
+  @override
   String get updateAction => 'Atualizar';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4,6 +4,7 @@
   "deleteAction": "Deletar",
   "doNotSaveLabel": "Não salvar",
   "editAction": "Editar",
+  "rearrangeAction": "Reorganizar",
   "updateAction": "Atualizar",
   "manageAction": "Gerenciar",
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -9,7 +9,7 @@ import 'package:hidroly/provider/settings_provider.dart';
 import 'package:hidroly/theme/app_colors.dart';
 import 'package:hidroly/utils/app_date_utils.dart';
 import 'package:hidroly/widgets/home/daily_history_bottom_sheet.dart';
-import 'package:hidroly/widgets/home/fab_custom_cup.dart';
+import 'package:hidroly/widgets/home/fab_home.dart';
 import 'package:hidroly/widgets/home/water_action_buttons.dart';
 import 'package:hidroly/widgets/home/water_progress_circle.dart';
 import 'package:provider/provider.dart';
@@ -71,7 +71,7 @@ class _HomePageState extends State<HomePage> {
           ),
         ),
       ),
-      floatingActionButton: FabCustomCup(
+      floatingActionButton: FabHome(
         dayId: dayId,
         isMetric: isMetric
       ),

--- a/lib/provider/app_state_provider.dart
+++ b/lib/provider/app_state_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class AppStateProvider extends ChangeNotifier {
-  bool _editMode = true;
+  bool _editMode = false;
 
   bool get editMode {
     return _editMode;

--- a/lib/provider/app_state_provider.dart
+++ b/lib/provider/app_state_provider.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
 
 class AppStateProvider extends ChangeNotifier {
-  bool _editMode = false;
-  set editMode (bool value) {
+  bool _editMode = true;
+
+  bool get editMode {
+    return _editMode;
+  }
+
+  set editMode(bool value) {
     _editMode = value;
+    notifyListeners();
   }
 }

--- a/lib/provider/app_state_provider.dart
+++ b/lib/provider/app_state_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class AppStateProvider extends ChangeNotifier {
+  bool _editMode = false;
+  set editMode (bool value) {
+    _editMode = value;
+  }
+}

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -61,7 +61,5 @@ class CustomCupsProvider extends ChangeNotifier {
       
       await _customCupsRepository.updateCustomCup(modifiedWaterButton);
     }
-    
-    await loadCustomCups();
   }
 }

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -51,8 +51,17 @@ class CustomCupsProvider extends ChangeNotifier {
     return true;
   }
 
-  void reorderCups(int oldPos, int newPos) {
-    final movedCup = customCups.removeAt(oldPos);
-    customCups.insert(newPos, movedCup);
+  Future<void> reorderCups(int oldPos, int newPos) async {
+    final movedCup = _customCups.removeAt(oldPos);
+    _customCups.insert(newPos, movedCup);
+
+    for(WaterButton waterButton in _customCups) {
+      final modifiedWaterButton =
+        waterButton.copyWith(position: _customCups.indexOf(waterButton));
+      
+      await _customCupsRepository.updateCustomCup(modifiedWaterButton);
+    }
+    
+    await loadCustomCups();
   }
 }

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -22,7 +22,7 @@ class CustomCupsProvider extends ChangeNotifier {
     if(customCupAmount <= 0) return false;
 
     await _customCupsRepository.createCustomCup(
-      WaterButton(amount: customCupAmount, position: _customCups.length),
+      WaterButton(amount: customCupAmount),
     );
 
     await loadCustomCups();

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -22,7 +22,7 @@ class CustomCupsProvider extends ChangeNotifier {
     if(customCupAmount <= 0) return false;
 
     await _customCupsRepository.createCustomCup(
-      WaterButton(amount: customCupAmount),
+      WaterButton(amount: customCupAmount, position: _customCups.length),
     );
 
     await loadCustomCups();

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -50,4 +50,9 @@ class CustomCupsProvider extends ChangeNotifier {
     await loadCustomCups();
     return true;
   }
+
+  void reorderCups(int oldPos, int newPos) {
+    final movedCup = customCups.removeAt(oldPos);
+    customCups.insert(newPos, movedCup);
+  }
 }

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -15,7 +15,6 @@ class CustomCupsProvider extends ChangeNotifier {
 
   Future<void> loadCustomCups() async {
     _customCups = await _customCupsRepository.loadCustomCups();
-    print(_customCups);
     notifyListeners();
   }
 

--- a/lib/provider/custom_cups_provider.dart
+++ b/lib/provider/custom_cups_provider.dart
@@ -15,14 +15,18 @@ class CustomCupsProvider extends ChangeNotifier {
 
   Future<void> loadCustomCups() async {
     _customCups = await _customCupsRepository.loadCustomCups();
+    print(_customCups);
     notifyListeners();
   }
 
-  Future<bool> createCustomCup(int customCupAmount) async {
+  Future<bool> createCustomCup(int customCupAmount, { int? position }) async {
     if(customCupAmount <= 0) return false;
 
     await _customCupsRepository.createCustomCup(
-      WaterButton(amount: customCupAmount),
+      WaterButton(
+        amount: customCupAmount, 
+        position: position ?? _customCups.length,
+      ),
     );
 
     await loadCustomCups();

--- a/lib/widgets/home/fab_home.dart
+++ b/lib/widgets/home/fab_home.dart
@@ -160,5 +160,6 @@ class _FabHomeState extends State<FabHome> {
 
   void _toggleEditMode(bool editMode) {
     context.read<AppStateProvider>().editMode = !editMode;
+    context.read<CustomCupsProvider>().loadCustomCups();
   }
 }

--- a/lib/widgets/home/fab_home.dart
+++ b/lib/widgets/home/fab_home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hidroly/data/model/history_entry.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/provider/app_state_provider.dart';
 import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
@@ -8,8 +9,8 @@ import 'package:hidroly/utils/unit_tools.dart';
 import 'package:hidroly/widgets/input/form_number_input_field.dart';
 import 'package:provider/provider.dart';
 
-class FabCustomCup extends StatefulWidget {
-  const FabCustomCup({
+class FabHome extends StatefulWidget {
+  const FabHome({
     super.key,
     required this.dayId,
     required this.isMetric,
@@ -19,10 +20,10 @@ class FabCustomCup extends StatefulWidget {
   final bool isMetric;
 
   @override
-  State<FabCustomCup> createState() => _FabCustomCupState();
+  State<FabHome> createState() => _FabHomeState();
 }
 
-class _FabCustomCupState extends State<FabCustomCup> {
+class _FabHomeState extends State<FabHome> {
   final TextEditingController customCupAmountController = TextEditingController();
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
@@ -34,11 +35,16 @@ class _FabCustomCupState extends State<FabCustomCup> {
 
   @override
   Widget build(BuildContext context) {
+    final editMode =
+      context.watch<AppStateProvider>().editMode;
+
     return FloatingActionButton(
-      onPressed: () => _showCustomCupPopUp(context),
-      child: Icon(
-        Icons.add,
-      ),
+      onPressed: () => editMode
+        ? _toggleEditMode(editMode)
+        : _showCustomCupPopUp(context),
+      child: editMode 
+        ? Icon(Icons.done)
+        : Icon(Icons.add)
     );
   }
 
@@ -150,5 +156,9 @@ class _FabCustomCupState extends State<FabCustomCup> {
         );
       }
     );
+  }
+
+  void _toggleEditMode(bool editMode) {
+    context.read<AppStateProvider>().editMode = !editMode;
   }
 }

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -49,7 +49,8 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
         shrinkWrap: true,
         scrollDirection: Axis.horizontal,
         onReorder: (oldPos, newPos) {
-          // TODO: Reorder logic
+          context.read<CustomCupsProvider>()
+            .reorderCups(oldPos, newPos);
         },
         itemBuilder: (context, index) {
           var cup = customCups[index];

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -61,156 +61,163 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
         itemBuilder: (context, index) {
           var cup = customCups[index];
 
-          return GestureDetector(
+          return Row(
             key: Key(cup.id.toString()),
-            onLongPressStart: !editMode
-              ? (details) async {
-                final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-                final Offset tapPosition = details.globalPosition;
-
-                await showMenu(
-                  context: context, 
-                  items: <PopupMenuEntry<String>>[
-                    PopupMenuItem(
-                      child: Row(
-                        spacing: 12,
-                        children: [
-                          Icon(
-                            Icons.edit,
-                            color: Theme.of(context).iconTheme.color
-                          ),
-                          Text(
-                            AppLocalizations.of(context)!.editAction,
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.labelMedium!.color
-                            )
-                          ),
-                        ],
-                      ),
-                      onTap: () async {
-                        await showDialog(
-                          context: context, 
-                          builder: (context) {
-                            return Form(
-                              key: formKey,
-                              child: NumberInputDialog(
-                                title: AppLocalizations.of(context)!.editCustomCupDialogTitle, 
-                                inputFieldLabel: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
-                                actionButtonText: AppLocalizations.of(context)!.updateAction, 
-                                cancelButtonText: AppLocalizations.of(context)!.cancelAction, 
-                                inputFieldValidator: (value) {
-                                  double? amount = double.tryParse(value ?? '');
-                                  if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
-                                  return null;
-                                },
-                                onActionPressed: () async {
-                                  if(!formKey.currentState!.validate()) return;
-
-                                  double amount = double.parse(updateDialogTextController.text);
-                                  int metricAmount = widget.isMetric 
-                                    ? amount.round()
-                                    : UnitTools.flOzToMl(amount);
-                                  
-                                  WaterButton updatedCup = cup.copyWith(amount: metricAmount);
-                                  bool success = await context.read<CustomCupsProvider>()
-                                    .updateCustomCup(updatedCup);
-
-                                  if(!context.mounted) return;
-
-                                  String message = success
-                                    ? AppLocalizations.of(context)!.editCustomCupSuccess
-                                    : AppLocalizations.of(context)!.editCustomCupFailed;
-                                  
-                                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                                      content: Text(message)
-                                    )
-                                  );
-
-                                  Navigator.of(context).pop();
-                                  updateDialogTextController.clear();
-                                },
-                                onCancelPressed: () {
-                                  Navigator.of(context).pop();
-                                  updateDialogTextController.clear();
-                                }, 
-                                textEditingController: updateDialogTextController,
+            children: [
+              GestureDetector(
+                onLongPressStart: !editMode
+                  ? (details) async {
+                    final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+                    final Offset tapPosition = details.globalPosition;
+              
+                    await showMenu(
+                      context: context, 
+                      items: <PopupMenuEntry<String>>[
+                        PopupMenuItem(
+                          child: Row(
+                            spacing: 12,
+                            children: [
+                              Icon(
+                                Icons.edit,
+                                color: Theme.of(context).iconTheme.color
                               ),
+                              Text(
+                                AppLocalizations.of(context)!.editAction,
+                                style: TextStyle(
+                                  color: Theme.of(context).textTheme.labelMedium!.color
+                                )
+                              ),
+                            ],
+                          ),
+                          onTap: () async {
+                            await showDialog(
+                              context: context, 
+                              builder: (context) {
+                                return Form(
+                                  key: formKey,
+                                  child: NumberInputDialog(
+                                    title: AppLocalizations.of(context)!.editCustomCupDialogTitle, 
+                                    inputFieldLabel: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
+                                    actionButtonText: AppLocalizations.of(context)!.updateAction, 
+                                    cancelButtonText: AppLocalizations.of(context)!.cancelAction, 
+                                    inputFieldValidator: (value) {
+                                      double? amount = double.tryParse(value ?? '');
+                                      if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
+                                      return null;
+                                    },
+                                    onActionPressed: () async {
+                                      if(!formKey.currentState!.validate()) return;
+              
+                                      double amount = double.parse(updateDialogTextController.text);
+                                      int metricAmount = widget.isMetric 
+                                        ? amount.round()
+                                        : UnitTools.flOzToMl(amount);
+                                      
+                                      WaterButton updatedCup = cup.copyWith(amount: metricAmount);
+                                      bool success = await context.read<CustomCupsProvider>()
+                                        .updateCustomCup(updatedCup);
+              
+                                      if(!context.mounted) return;
+              
+                                      String message = success
+                                        ? AppLocalizations.of(context)!.editCustomCupSuccess
+                                        : AppLocalizations.of(context)!.editCustomCupFailed;
+                                      
+                                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                                          content: Text(message)
+                                        )
+                                      );
+              
+                                      Navigator.of(context).pop();
+                                      updateDialogTextController.clear();
+                                    },
+                                    onCancelPressed: () {
+                                      Navigator.of(context).pop();
+                                      updateDialogTextController.clear();
+                                    }, 
+                                    textEditingController: updateDialogTextController,
+                                  ),
+                                );
+                              }
                             );
-                          }
-                        );
-                      },
-                    ),
-                    PopupMenuItem(
-                      child: Row(
-                        spacing: 12,
-                        children: [
-                          Icon(
-                            Icons.swap_horiz,
-                            color: Theme.of(context).iconTheme.color,
+                          },
+                        ),
+                        PopupMenuItem(
+                          child: Row(
+                            spacing: 12,
+                            children: [
+                              Icon(
+                                Icons.swap_horiz,
+                                color: Theme.of(context).iconTheme.color,
+                              ),
+                              Text(
+                                AppLocalizations.of(context)!.rearrangeAction,
+                                style: TextStyle(
+                                  color: Theme.of(context).textTheme.labelMedium!.color
+                                ),
+                              ),
+                            ],
                           ),
-                          Text(
-                            AppLocalizations.of(context)!.rearrangeAction,
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.labelMedium!.color
-                            ),
+                          onTap: () async {
+                            context.read<AppStateProvider>().editMode = true;
+                          },
+                        ),
+                        PopupMenuItem(
+                          child: Row(
+                            spacing: 12,
+                            children: [
+                              Icon(
+                                Icons.delete_forever,
+                                color: Colors.redAccent,
+                              ),
+                              Text(
+                                AppLocalizations.of(context)!.deleteAction,
+                                style: TextStyle(
+                                  color: Colors.redAccent
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
+                          onTap: () async {
+                            await context.read<CustomCupsProvider>()
+                              .deleteCustomCup(cup.id!);
+                          },
+                        ),
+                      ],
+                      color: Theme.of(context).colorScheme.onSurface,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadiusGeometry.circular(12)
                       ),
-                      onTap: () async {
-                        context.read<AppStateProvider>().editMode = true;
-                      },
-                    ),
-                    PopupMenuItem(
-                      child: Row(
-                        spacing: 12,
-                        children: [
-                          Icon(
-                            Icons.delete_forever,
-                            color: Colors.redAccent,
-                          ),
-                          Text(
-                            AppLocalizations.of(context)!.deleteAction,
-                            style: TextStyle(
-                              color: Colors.redAccent
-                            ),
-                          ),
-                        ],
+                      position: RelativeRect.fromRect(
+                        tapPosition & Size(40, 40), // Size of the menu
+                        Offset.zero & overlay.size,
                       ),
-                      onTap: () async {
-                        await context.read<CustomCupsProvider>()
-                          .deleteCustomCup(cup.id!);
-                      },
-                    ),
-                  ],
-                  color: Theme.of(context).colorScheme.onSurface,
+                    );
+                }
+                : null,
+                child: ActionChip(
+                  onPressed: () async {
+                    final int amount = cup.amount;
+                    await addWater(context, amount);
+                
+                    if(!context.mounted) return;
+                    await saveWaterToHistory(context, amount);
+                  },
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadiusGeometry.circular(12)
                   ),
-                  position: RelativeRect.fromRect(
-                    tapPosition & Size(40, 40), // Size of the menu
-                    Offset.zero & overlay.size,
+                  avatar: Icon(Icons.water_drop),
+                  backgroundColor: Theme.of(context).colorScheme.onSurface,
+                  label: Text(
+                    UnitTools.getVolumeWithUnit(cup.amount, widget.isMetric, context: context),
+                    style: Theme.of(context).textTheme.labelLarge
                   ),
-                );
-            }
-            : null,
-            child: ActionChip(
-              onPressed: () async {
-                final int amount = cup.amount;
-                await addWater(context, amount);
-            
-                if(!context.mounted) return;
-                await saveWaterToHistory(context, amount);
-              },
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadiusGeometry.circular(12)
+                ),
               ),
-              avatar: Icon(Icons.water_drop),
-              backgroundColor: Theme.of(context).colorScheme.onSurface,
-              label: Text(
-                UnitTools.getVolumeWithUnit(cup.amount, widget.isMetric, context: context),
-                style: Theme.of(context).textTheme.labelLarge
-              ),
-            ),
+
+              if(index < customCups.length - 1)
+                SizedBox(width: 8,),
+            ],
           );
         },
         itemCount: customCups.length

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -39,144 +39,153 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
     final List<WaterButton> customCups = 
       context.watch<CustomCupsProvider>().customCups;
 
+    final editMode =
+      context.watch<AppStateProvider>().editMode;
+
     return Container(
       height: 45,
       margin: EdgeInsets.only(left: 15, right: 15),
-      child: ListView.separated(
+      child: ReorderableListView.builder(
         shrinkWrap: true,
         scrollDirection: Axis.horizontal,
+        onReorder: (oldPos, newPos) {
+          // TODO: Reorder logic
+        },
         itemBuilder: (context, index) {
           var cup = customCups[index];
 
           return GestureDetector(
-            onLongPressStart: (details) async {
-              final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-              final Offset tapPosition = details.globalPosition;
+            key: Key(cup.id.toString()),
+            onLongPressStart: !editMode
+              ? (details) async {
+                final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+                final Offset tapPosition = details.globalPosition;
 
-              await showMenu(
-                context: context, 
-                items: <PopupMenuEntry<String>>[
-                  PopupMenuItem(
-                    child: Row(
-                      spacing: 12,
-                      children: [
-                        Icon(
-                          Icons.edit,
-                          color: Theme.of(context).iconTheme.color
-                        ),
-                        Text(
-                          AppLocalizations.of(context)!.editAction,
-                          style: TextStyle(
-                            color: Theme.of(context).textTheme.labelMedium!.color
-                          )
-                        ),
-                      ],
+                await showMenu(
+                  context: context, 
+                  items: <PopupMenuEntry<String>>[
+                    PopupMenuItem(
+                      child: Row(
+                        spacing: 12,
+                        children: [
+                          Icon(
+                            Icons.edit,
+                            color: Theme.of(context).iconTheme.color
+                          ),
+                          Text(
+                            AppLocalizations.of(context)!.editAction,
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.labelMedium!.color
+                            )
+                          ),
+                        ],
+                      ),
+                      onTap: () async {
+                        await showDialog(
+                          context: context, 
+                          builder: (context) {
+                            return Form(
+                              key: formKey,
+                              child: NumberInputDialog(
+                                title: AppLocalizations.of(context)!.editCustomCupDialogTitle, 
+                                inputFieldLabel: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
+                                actionButtonText: AppLocalizations.of(context)!.updateAction, 
+                                cancelButtonText: AppLocalizations.of(context)!.cancelAction, 
+                                inputFieldValidator: (value) {
+                                  double? amount = double.tryParse(value ?? '');
+                                  if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
+                                  return null;
+                                },
+                                onActionPressed: () async {
+                                  if(!formKey.currentState!.validate()) return;
+
+                                  double amount = double.parse(updateDialogTextController.text);
+                                  int metricAmount = widget.isMetric 
+                                    ? amount.round()
+                                    : UnitTools.flOzToMl(amount);
+                                  
+                                  WaterButton updatedCup = cup.copyWith(amount: metricAmount);
+                                  bool success = await context.read<CustomCupsProvider>()
+                                    .updateCustomCup(updatedCup);
+
+                                  if(!context.mounted) return;
+
+                                  String message = success
+                                    ? AppLocalizations.of(context)!.editCustomCupSuccess
+                                    : AppLocalizations.of(context)!.editCustomCupFailed;
+                                  
+                                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                                      content: Text(message)
+                                    )
+                                  );
+
+                                  Navigator.of(context).pop();
+                                  updateDialogTextController.clear();
+                                },
+                                onCancelPressed: () {
+                                  Navigator.of(context).pop();
+                                  updateDialogTextController.clear();
+                                }, 
+                                textEditingController: updateDialogTextController,
+                              ),
+                            );
+                          }
+                        );
+                      },
                     ),
-                    onTap: () async {
-                      await showDialog(
-                        context: context, 
-                        builder: (context) {
-                          return Form(
-                            key: formKey,
-                            child: NumberInputDialog(
-                              title: AppLocalizations.of(context)!.editCustomCupDialogTitle, 
-                              inputFieldLabel: AppLocalizations.of(context)!.customCupDialogTextFieldAmount, 
-                              actionButtonText: AppLocalizations.of(context)!.updateAction, 
-                              cancelButtonText: AppLocalizations.of(context)!.cancelAction, 
-                              inputFieldValidator: (value) {
-                                double? amount = double.tryParse(value ?? '');
-                                if(amount == null || amount <= 0) return AppLocalizations.of(context)!.textFieldAmountError;
-                                return null;
-                              },
-                              onActionPressed: () async {
-                                if(!formKey.currentState!.validate()) return;
-
-                                double amount = double.parse(updateDialogTextController.text);
-                                int metricAmount = widget.isMetric 
-                                  ? amount.round()
-                                  : UnitTools.flOzToMl(amount);
-                                
-                                WaterButton updatedCup = cup.copyWith(amount: metricAmount);
-                                bool success = await context.read<CustomCupsProvider>()
-                                  .updateCustomCup(updatedCup);
-
-                                if(!context.mounted) return;
-
-                                String message = success
-                                  ? AppLocalizations.of(context)!.editCustomCupSuccess
-                                  : AppLocalizations.of(context)!.editCustomCupFailed;
-                                
-                                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                                    content: Text(message)
-                                  )
-                                );
-
-                                Navigator.of(context).pop();
-                                updateDialogTextController.clear();
-                              },
-                              onCancelPressed: () {
-                                Navigator.of(context).pop();
-                                updateDialogTextController.clear();
-                              }, 
-                              textEditingController: updateDialogTextController,
+                    PopupMenuItem(
+                      child: Row(
+                        spacing: 12,
+                        children: [
+                          Icon(
+                            Icons.swap_horiz,
+                            color: Theme.of(context).iconTheme.color,
+                          ),
+                          Text(
+                            AppLocalizations.of(context)!.rearrangeAction,
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.labelMedium!.color
                             ),
-                          );
-                        }
-                      );
-                    },
-                  ),
-                  PopupMenuItem(
-                    child: Row(
-                      spacing: 12,
-                      children: [
-                        Icon(
-                          Icons.swap_horiz,
-                          color: Theme.of(context).iconTheme.color,
-                        ),
-                        Text(
-                          AppLocalizations.of(context)!.rearrangeAction,
-                          style: TextStyle(
-                            color: Theme.of(context).textTheme.labelMedium!.color
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
+                      onTap: () async {
+                        context.read<AppStateProvider>().editMode = true;
+                      },
                     ),
-                    onTap: () async {
-                      context.read<AppStateProvider>().editMode = true;
-                    },
-                  ),
-                  PopupMenuItem(
-                    child: Row(
-                      spacing: 12,
-                      children: [
-                        Icon(
-                          Icons.delete_forever,
-                          color: Colors.redAccent,
-                        ),
-                        Text(
-                          AppLocalizations.of(context)!.deleteAction,
-                          style: TextStyle(
-                            color: Colors.redAccent
+                    PopupMenuItem(
+                      child: Row(
+                        spacing: 12,
+                        children: [
+                          Icon(
+                            Icons.delete_forever,
+                            color: Colors.redAccent,
                           ),
-                        ),
-                      ],
+                          Text(
+                            AppLocalizations.of(context)!.deleteAction,
+                            style: TextStyle(
+                              color: Colors.redAccent
+                            ),
+                          ),
+                        ],
+                      ),
+                      onTap: () async {
+                        await context.read<CustomCupsProvider>()
+                          .deleteCustomCup(cup.id!);
+                      },
                     ),
-                    onTap: () async {
-                      await context.read<CustomCupsProvider>()
-                        .deleteCustomCup(cup.id!);
-                    },
+                  ],
+                  color: Theme.of(context).colorScheme.onSurface,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadiusGeometry.circular(12)
                   ),
-                ],
-                color: Theme.of(context).colorScheme.onSurface,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadiusGeometry.circular(12)
-                ),
-                position: RelativeRect.fromRect(
-                  tapPosition & Size(40, 40), // Size of the menu
-                  Offset.zero & overlay.size,
-                ),
-              );
-            },
+                  position: RelativeRect.fromRect(
+                    tapPosition & Size(40, 40), // Size of the menu
+                    Offset.zero & overlay.size,
+                  ),
+                );
+            }
+            : null,
             child: ActionChip(
               onPressed: () async {
                 final int amount = cup.amount;
@@ -196,8 +205,7 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
               ),
             ),
           );
-        }, 
-        separatorBuilder: (context, index) => SizedBox(width: 10,), 
+        },
         itemCount: customCups.length
       ),
     );

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -50,6 +50,7 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
       child: ReorderableListView.builder(
         shrinkWrap: true,
         scrollDirection: Axis.horizontal,
+        proxyDecorator: proxyDecorator,
         onReorder: (oldPos, newPos) {
           if(oldPos < newPos) {
             newPos -= 1;
@@ -222,6 +223,20 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
         },
         itemCount: customCups.length
       ),
+    );
+  }
+
+  Widget proxyDecorator(Widget child, int index, Animation<double> animation) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (BuildContext context, Widget? child) {
+        return Material(
+          elevation: 0,
+          color: Colors.transparent,
+          child: child,
+        );
+      },
+      child: child,
     );
   }
 

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hidroly/data/model/history_entry.dart';
 import 'package:hidroly/data/model/water_button.dart';
 import 'package:hidroly/l10n/app_localizations.dart';
+import 'package:hidroly/provider/app_state_provider.dart';
 import 'package:hidroly/provider/custom_cups_provider.dart';
 import 'package:hidroly/provider/daily_history_provider.dart';
 import 'package:hidroly/provider/day_provider.dart';
@@ -122,6 +123,26 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
                           );
                         }
                       );
+                    },
+                  ),
+                  PopupMenuItem(
+                    child: Row(
+                      spacing: 12,
+                      children: [
+                        Icon(
+                          Icons.swap_horiz,
+                          color: Theme.of(context).iconTheme.color,
+                        ),
+                        Text(
+                          AppLocalizations.of(context)!.rearrangeAction,
+                          style: TextStyle(
+                            color: Theme.of(context).textTheme.labelMedium!.color
+                          ),
+                        ),
+                      ],
+                    ),
+                    onTap: () async {
+                      context.read<AppStateProvider>().editMode = true;
                     },
                   ),
                   PopupMenuItem(

--- a/lib/widgets/home/water_action_buttons.dart
+++ b/lib/widgets/home/water_action_buttons.dart
@@ -38,9 +38,11 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
   Widget build(BuildContext context) {
     final List<WaterButton> customCups = 
       context.watch<CustomCupsProvider>().customCups;
-
+    
     final editMode =
       context.watch<AppStateProvider>().editMode;
+
+    customCups.sort((a, b) => a.position!.compareTo(b.position!));
 
     return Container(
       height: 45,
@@ -49,6 +51,10 @@ class _WaterActionButtonsState extends State<WaterActionButtons> {
         shrinkWrap: true,
         scrollDirection: Axis.horizontal,
         onReorder: (oldPos, newPos) {
+          if(oldPos < newPos) {
+            newPos -= 1;
+          }
+
           context.read<CustomCupsProvider>()
             .reorderCups(oldPos, newPos);
         },


### PR DESCRIPTION
# Description
This PR adds functionality for reordering cups in the app, providing users with a more flexible way to organize their custom cups. The changes include the ability to rearrange cups via a new reorderable list view and a corresponding "Rearrange" option in the water action buttons menu.

# Changes
* Reorderable List View: Introduced a new reorderable list view for cups, enabling users to drag and drop items to rearrange their order.
* Rearrange Popup Menu Item: Added a new "Rearrange" option in the water action buttons to trigger the reordering process.

# Preview
<img src="https://github.com/user-attachments/assets/c44bfd17-9a86-48ef-8242-27cce168a8ae" width=200>
<img src="https://github.com/user-attachments/assets/337bfdb9-248b-44a9-b04f-490e4f525423" width=200>
<img src="https://github.com/user-attachments/assets/237a947b-bad1-4b32-8e3a-ebd054ea79cb" width=200>

