### PR TITLE
fix: load haptic feedback toggle state on initialization

### DIFF
--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -30,6 +30,7 @@ class SettingsProvider extends ChangeNotifier {
 
   Future<void> loadAllSettings() async {
     await readIsMetric();
+    await readHapticFeedback();
     await readTime(Settings.wakeUpTime);
     await readTime(Settings.sleepTime);
   }


### PR DESCRIPTION
# Description
This PR fixes the issue #107 by actually loading the toggle state data when initializing the app.