### PR TITLE
feat: add chart to the summary page

### DIFF
--- a/lib/core/data/repositories/day_repository_impl.dart
+++ b/lib/core/data/repositories/day_repository_impl.dart
@@ -47,6 +47,17 @@ class DayRepositoryImpl implements DayRepository {
     
     return [for(final day in dayTableDataList) day.toEntity()];
   }
+
+  @override
+  Future<List<Day>> readByRange(DateTime start, DateTime end) async {
+    final dayTableDataList = await (_database
+      .select(_database.dayTable)
+      ..orderBy([(u) => OrderingTerm(expression: u.createdAt, mode: .desc)])
+      ..where((day) => day.createdAt.isBiggerOrEqualValue(start) & day.createdAt.isSmallerOrEqualValue(end)))
+      .get();
+    
+    return [for(final day in dayTableDataList) day.toEntity()];
+  }
   
   @override
   Future<Day> readOrCreateByDate(DateTime date) async {

--- a/lib/core/data/repositories/day_repository_impl.dart
+++ b/lib/core/data/repositories/day_repository_impl.dart
@@ -52,7 +52,7 @@ class DayRepositoryImpl implements DayRepository {
   Future<List<Day>> readByRange(DateTime start, DateTime end) async {
     final dayTableDataList = await (_database
       .select(_database.dayTable)
-      ..orderBy([(u) => OrderingTerm(expression: u.createdAt, mode: .desc)])
+      ..orderBy([(u) => OrderingTerm(expression: u.createdAt, mode: .asc)])
       ..where((day) => day.createdAt.isBiggerOrEqualValue(start) & day.createdAt.isSmallerOrEqualValue(end)))
       .get();
     

--- a/lib/core/domain/repositories/day_repository.dart
+++ b/lib/core/domain/repositories/day_repository.dart
@@ -4,5 +4,6 @@ abstract class DayRepository {
   Future<int> save(Day day);
   Future<Day> read(int id);
   Future<List<Day>> readAll();
+  Future<List<Day>> readByRange(DateTime start, DateTime end);
   Future<Day> readOrCreateByDate(DateTime date);
 }

--- a/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
@@ -19,8 +19,8 @@ class GetMonthlyChartDataUsecase {
 
   const GetMonthlyChartDataUsecase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
-    final today = DateTime.now();
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem, {DateTime? baseDate}) async {
+    final today = baseDate ?? DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
     final firstMonthDay = DateTime(today.year, today.month, 1);

--- a/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
@@ -1,0 +1,43 @@
+import 'package:collection/collection.dart';
+import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
+import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'get_monthly_chart_data_usecase.g.dart';
+
+@riverpod
+GetMonthlyChartDataUsecase getMonthlyChartDataUseCase(Ref ref) {
+  final dayRepository = ref.watch(dayRepositoryProvider);
+  return GetMonthlyChartDataUsecase(dayRepository);
+}
+
+class GetMonthlyChartDataUsecase {
+  final DayRepository _dayRepository;
+
+  const GetMonthlyChartDataUsecase(this._dayRepository);
+  
+  Future<List<Map<String, dynamic>>> execute() async {
+    final today = DateTime.now();
+    final normalizedToday = DateTime(today.year, today.month, today.day);
+
+    final firstMonthDay = DateTime(today.year, today.month, 1);
+
+    final days = await _dayRepository.readByRange(firstMonthDay, normalizedToday);
+
+    final weekGroups = groupBy(days, (Day day) {
+      final createdAtDay = day.createdAt.day;
+      final week = ((createdAtDay - 1) / 7).floor() + 1;
+      return week;
+    });
+    
+    return weekGroups.entries.map((entry) {
+      final week = entry.key;
+      final days = entry.value;
+
+      final weekSum = days.fold(0, (prev, currentDay) => prev + currentDay.currentAmount.ml);
+
+      return {'period': week.toString(), 'amount': weekSum};
+    }).toList();
+  }
+}

--- a/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart
@@ -1,7 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'get_monthly_chart_data_usecase.g.dart';
@@ -17,7 +19,7 @@ class GetMonthlyChartDataUsecase {
 
   const GetMonthlyChartDataUsecase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute() async {
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
@@ -37,7 +39,7 @@ class GetMonthlyChartDataUsecase {
 
       final weekSum = days.fold(0, (prev, currentDay) => prev + currentDay.currentAmount.ml);
 
-      return {'period': week.toString(), 'amount': weekSum};
+      return {'period': week.toString(), 'amount': Water.ml(weekSum).valueIn(unitSystem)};
     }).toList();
   }
 }

--- a/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.g.dart
+++ b/lib/features/summary/domain/usecases/get_monthly_chart_data_usecase.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_monthly_chart_data_usecase.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(getMonthlyChartDataUseCase)
+final getMonthlyChartDataUseCaseProvider =
+    GetMonthlyChartDataUseCaseProvider._();
+
+final class GetMonthlyChartDataUseCaseProvider
+    extends
+        $FunctionalProvider<
+          GetMonthlyChartDataUsecase,
+          GetMonthlyChartDataUsecase,
+          GetMonthlyChartDataUsecase
+        >
+    with $Provider<GetMonthlyChartDataUsecase> {
+  GetMonthlyChartDataUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'getMonthlyChartDataUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$getMonthlyChartDataUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<GetMonthlyChartDataUsecase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GetMonthlyChartDataUsecase create(Ref ref) {
+    return getMonthlyChartDataUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GetMonthlyChartDataUsecase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GetMonthlyChartDataUsecase>(value),
+    );
+  }
+}
+
+String _$getMonthlyChartDataUseCaseHash() =>
+    r'c432b6b903ee255ac4b15c6a9092e8de0eeb5f2b';

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/repositories/day_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,7 +17,7 @@ class GetWeeklyChartDataUseCase {
 
   const GetWeeklyChartDataUseCase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute() async {
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
@@ -29,7 +30,7 @@ class GetWeeklyChartDataUseCase {
       final day = days[index];
       final weekDayAbbr = _getLocalizedDayAbbr(day.createdAt);
 
-      return {'period': weekDayAbbr, 'amount': day.currentAmount.ml};
+      return {'period': weekDayAbbr, 'amount': day.currentAmount.valueIn(unitSystem)};
     });
   }
 

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
@@ -26,7 +26,6 @@ class GetWeeklyChartDataUseCase {
     
     return List.generate(days.length, (index) {
       final day = days[index];
-      print(day);
       return {'period': day.createdAt.day.toString(), 'amount': day.currentAmount.ml};
     });
   }

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
@@ -17,8 +17,8 @@ class GetWeeklyChartDataUseCase {
 
   const GetWeeklyChartDataUseCase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
-    final today = DateTime.now();
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem, {DateTime? baseDate}) async {
+    final today = baseDate ?? DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
     final weekDay = normalizedToday.weekday;

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
@@ -1,0 +1,33 @@
+import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'get_weekly_chart_data_usecase.g.dart';
+
+@riverpod
+GetWeeklyChartDataUseCase getWeeklyChartDataUseCase(Ref ref) {
+  final dayRepository = ref.watch(dayRepositoryProvider);
+  return GetWeeklyChartDataUseCase(dayRepository);
+}
+
+class GetWeeklyChartDataUseCase {
+  final DayRepository _dayRepository;
+
+  const GetWeeklyChartDataUseCase(this._dayRepository);
+  
+  Future<List<Map<String, dynamic>>> execute() async {
+    final today = DateTime.now();
+    final normalizedToday = DateTime(today.year, today.month, today.day);
+
+    final weekDay = normalizedToday.day % 7;
+    final firstWeekDay = normalizedToday.subtract(Duration(days: weekDay));
+
+    final days = await _dayRepository.readByRange(firstWeekDay, normalizedToday);
+    
+    return List.generate(days.length, (index) {
+      final day = days[index];
+      print(day);
+      return {'period': day.createdAt.day.toString(), 'amount': day.currentAmount.ml};
+    });
+  }
+}

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/core/domain/repositories/day_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -19,14 +20,20 @@ class GetWeeklyChartDataUseCase {
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
-    final weekDay = normalizedToday.day % 7;
+    final weekDay = normalizedToday.weekday;
     final firstWeekDay = normalizedToday.subtract(Duration(days: weekDay));
 
     final days = await _dayRepository.readByRange(firstWeekDay, normalizedToday);
     
     return List.generate(days.length, (index) {
       final day = days[index];
-      return {'period': day.createdAt.day.toString(), 'amount': day.currentAmount.ml};
+      final weekDayAbbr = _getLocalizedDayAbbr(day.createdAt);
+
+      return {'period': weekDayAbbr, 'amount': day.currentAmount.ml};
     });
+  }
+
+  String _getLocalizedDayAbbr(DateTime date) {
+    return DateFormat.E().format(date);
   }
 }

--- a/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.g.dart
+++ b/lib/features/summary/domain/usecases/get_weekly_chart_data_usecase.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_weekly_chart_data_usecase.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(getWeeklyChartDataUseCase)
+final getWeeklyChartDataUseCaseProvider = GetWeeklyChartDataUseCaseProvider._();
+
+final class GetWeeklyChartDataUseCaseProvider
+    extends
+        $FunctionalProvider<
+          GetWeeklyChartDataUseCase,
+          GetWeeklyChartDataUseCase,
+          GetWeeklyChartDataUseCase
+        >
+    with $Provider<GetWeeklyChartDataUseCase> {
+  GetWeeklyChartDataUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'getWeeklyChartDataUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$getWeeklyChartDataUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<GetWeeklyChartDataUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GetWeeklyChartDataUseCase create(Ref ref) {
+    return getWeeklyChartDataUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GetWeeklyChartDataUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GetWeeklyChartDataUseCase>(value),
+    );
+  }
+}
+
+String _$getWeeklyChartDataUseCaseHash() =>
+    r'4e64ffdd50b9055cb1b8643533fe09716afa3e6a';

--- a/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
@@ -20,8 +20,8 @@ class GetYearlyChartDataUsecase {
 
   const GetYearlyChartDataUsecase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
-    final today = DateTime.now();
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem, {DateTime? baseDate}) async {
+    final today = baseDate ?? DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
     final firstYearDay = DateTime(today.year, 1, 1);

--- a/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/core/domain/entities/day.dart';
 import 'package:hidroly/core/domain/repositories/day_repository.dart';
@@ -34,8 +35,13 @@ class GetYearlyChartDataUsecase {
       final days = entry.value;
 
       final monthSum = days.fold(0, (prev, currentDay) => prev + currentDay.currentAmount.ml);
+      final monthAbbr = _getLocalizedMonthAbbr(DateTime(2026, month, 1));
 
-      return {'period': month.toString(), 'amount': monthSum};
+      return {'period': monthAbbr, 'amount': monthSum};
     }).toList();
+  }
+
+  String _getLocalizedMonthAbbr(DateTime date) {
+    return DateFormat.LLL().format(date);
   }
 }

--- a/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
@@ -1,0 +1,41 @@
+import 'package:collection/collection.dart';
+import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
+import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'get_yearly_chart_data_usecase.g.dart';
+
+@riverpod
+GetYearlyChartDataUsecase getYearlyChartDataUsecase(Ref ref) {
+  final dayRepository = ref.watch(dayRepositoryProvider);
+  return GetYearlyChartDataUsecase(dayRepository);
+}
+
+class GetYearlyChartDataUsecase {
+  final DayRepository _dayRepository;
+
+  const GetYearlyChartDataUsecase(this._dayRepository);
+  
+  Future<List<Map<String, dynamic>>> execute() async {
+    final today = DateTime.now();
+    final normalizedToday = DateTime(today.year, today.month, today.day);
+
+    final firstYearDay = DateTime(today.year, 1, 1);
+
+    final days = await _dayRepository.readByRange(firstYearDay, normalizedToday);
+
+    final monthGroups = groupBy(days, (Day day) {
+      return day.createdAt.month;
+    });
+    
+    return monthGroups.entries.map((entry) {
+      final month = entry.key;
+      final days = entry.value;
+
+      final monthSum = days.fold(0, (prev, currentDay) => prev + currentDay.currentAmount.ml);
+
+      return {'period': month.toString(), 'amount': monthSum};
+    }).toList();
+  }
+}

--- a/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
+++ b/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart
@@ -2,7 +2,9 @@ import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'get_yearly_chart_data_usecase.g.dart';
@@ -18,7 +20,7 @@ class GetYearlyChartDataUsecase {
 
   const GetYearlyChartDataUsecase(this._dayRepository);
   
-  Future<List<Map<String, dynamic>>> execute() async {
+  Future<List<Map<String, dynamic>>> execute(UnitSystem unitSystem) async {
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
 
@@ -37,7 +39,7 @@ class GetYearlyChartDataUsecase {
       final monthSum = days.fold(0, (prev, currentDay) => prev + currentDay.currentAmount.ml);
       final monthAbbr = _getLocalizedMonthAbbr(DateTime(2026, month, 1));
 
-      return {'period': monthAbbr, 'amount': monthSum};
+      return {'period': monthAbbr, 'amount': Water.ml(monthSum).valueIn(unitSystem)};
     }).toList();
   }
 

--- a/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.g.dart
+++ b/lib/features/summary/domain/usecases/get_yearly_chart_data_usecase.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_yearly_chart_data_usecase.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(getYearlyChartDataUsecase)
+final getYearlyChartDataUsecaseProvider = GetYearlyChartDataUsecaseProvider._();
+
+final class GetYearlyChartDataUsecaseProvider
+    extends
+        $FunctionalProvider<
+          GetYearlyChartDataUsecase,
+          GetYearlyChartDataUsecase,
+          GetYearlyChartDataUsecase
+        >
+    with $Provider<GetYearlyChartDataUsecase> {
+  GetYearlyChartDataUsecaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'getYearlyChartDataUsecaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$getYearlyChartDataUsecaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<GetYearlyChartDataUsecase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GetYearlyChartDataUsecase create(Ref ref) {
+    return getYearlyChartDataUsecase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GetYearlyChartDataUsecase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GetYearlyChartDataUsecase>(value),
+    );
+  }
+}
+
+String _$getYearlyChartDataUsecaseHash() =>
+    r'fb6894514b37ae4f6a37c61ab4d03bebb555fdf8';

--- a/lib/features/summary/ui/enums/chart_selection.dart
+++ b/lib/features/summary/ui/enums/chart_selection.dart
@@ -1,0 +1,1 @@
+enum ChartSelection { weekly, monthly, yearly }

--- a/lib/features/summary/ui/state/summary_state.dart
+++ b/lib/features/summary/ui/state/summary_state.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
+import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 
 part 'summary_state.freezed.dart';
 
@@ -11,5 +12,6 @@ abstract class SummaryState with _$SummaryState {
     @Default(Water.zero()) Water dailyAverage,
     @Default(0) int streak,
     @Default(UnitSystem.metric) UnitSystem unitSystem,
+    @Default(ChartSelection.weekly) ChartSelection chartSelection,
   }) = _SummaryState;
 }

--- a/lib/features/summary/ui/state/summary_state.dart
+++ b/lib/features/summary/ui/state/summary_state.dart
@@ -13,5 +13,6 @@ abstract class SummaryState with _$SummaryState {
     @Default(0) int streak,
     @Default(UnitSystem.metric) UnitSystem unitSystem,
     @Default(ChartSelection.weekly) ChartSelection chartSelection,
+    required List<Map<String, dynamic>> chartData,
   }) = _SummaryState;
 }

--- a/lib/features/summary/ui/state/summary_state.freezed.dart
+++ b/lib/features/summary/ui/state/summary_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SummaryState {
 
- Water get totalDrunk; Water get dailyAverage; int get streak; UnitSystem get unitSystem;
+ Water get totalDrunk; Water get dailyAverage; int get streak; UnitSystem get unitSystem; ChartSelection get chartSelection;
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SummaryStateCopyWith<SummaryState> get copyWith => _$SummaryStateCopyWithImpl<S
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem);
+int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection);
 
 @override
 String toString() {
-  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem)';
+  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SummaryStateCopyWith<$Res>  {
   factory $SummaryStateCopyWith(SummaryState value, $Res Function(SummaryState) _then) = _$SummaryStateCopyWithImpl;
 @useResult
 $Res call({
- Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem
+ Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection
 });
 
 
@@ -62,13 +62,14 @@ class _$SummaryStateCopyWithImpl<$Res>
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,}) {
   return _then(_self.copyWith(
 totalDrunk: null == totalDrunk ? _self.totalDrunk : totalDrunk // ignore: cast_nullable_to_non_nullable
 as Water,dailyAverage: null == dailyAverage ? _self.dailyAverage : dailyAverage // ignore: cast_nullable_to_non_nullable
 as Water,streak: null == streak ? _self.streak : streak // ignore: cast_nullable_to_non_nullable
 as int,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
-as UnitSystem,
+as UnitSystem,chartSelection: null == chartSelection ? _self.chartSelection : chartSelection // ignore: cast_nullable_to_non_nullable
+as ChartSelection,
   ));
 }
 
@@ -153,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SummaryState() when $default != null:
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
   return orElse();
 
 }
@@ -174,10 +175,10 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)  $default,) {final _that = this;
 switch (_that) {
 case _SummaryState():
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -194,10 +195,10 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)?  $default,) {final _that = this;
 switch (_that) {
 case _SummaryState() when $default != null:
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
   return null;
 
 }
@@ -209,13 +210,14 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 
 
 class _SummaryState implements SummaryState {
-  const _SummaryState({this.totalDrunk = const Water.zero(), this.dailyAverage = const Water.zero(), this.streak = 0, this.unitSystem = UnitSystem.metric});
+  const _SummaryState({this.totalDrunk = const Water.zero(), this.dailyAverage = const Water.zero(), this.streak = 0, this.unitSystem = UnitSystem.metric, this.chartSelection = ChartSelection.weekly});
   
 
 @override@JsonKey() final  Water totalDrunk;
 @override@JsonKey() final  Water dailyAverage;
 @override@JsonKey() final  int streak;
 @override@JsonKey() final  UnitSystem unitSystem;
+@override@JsonKey() final  ChartSelection chartSelection;
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
@@ -227,16 +229,16 @@ _$SummaryStateCopyWith<_SummaryState> get copyWith => __$SummaryStateCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem);
+int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection);
 
 @override
 String toString() {
-  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem)';
+  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection)';
 }
 
 
@@ -247,7 +249,7 @@ abstract mixin class _$SummaryStateCopyWith<$Res> implements $SummaryStateCopyWi
   factory _$SummaryStateCopyWith(_SummaryState value, $Res Function(_SummaryState) _then) = __$SummaryStateCopyWithImpl;
 @override @useResult
 $Res call({
- Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem
+ Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection
 });
 
 
@@ -264,13 +266,14 @@ class __$SummaryStateCopyWithImpl<$Res>
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,}) {
   return _then(_SummaryState(
 totalDrunk: null == totalDrunk ? _self.totalDrunk : totalDrunk // ignore: cast_nullable_to_non_nullable
 as Water,dailyAverage: null == dailyAverage ? _self.dailyAverage : dailyAverage // ignore: cast_nullable_to_non_nullable
 as Water,streak: null == streak ? _self.streak : streak // ignore: cast_nullable_to_non_nullable
 as int,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
-as UnitSystem,
+as UnitSystem,chartSelection: null == chartSelection ? _self.chartSelection : chartSelection // ignore: cast_nullable_to_non_nullable
+as ChartSelection,
   ));
 }
 

--- a/lib/features/summary/ui/state/summary_state.freezed.dart
+++ b/lib/features/summary/ui/state/summary_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SummaryState {
 
- Water get totalDrunk; Water get dailyAverage; int get streak; UnitSystem get unitSystem; ChartSelection get chartSelection;
+ Water get totalDrunk; Water get dailyAverage; int get streak; UnitSystem get unitSystem; ChartSelection get chartSelection; List<Map<String, dynamic>> get chartData;
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SummaryStateCopyWith<SummaryState> get copyWith => _$SummaryStateCopyWithImpl<S
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection)&&const DeepCollectionEquality().equals(other.chartData, chartData));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection);
+int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection,const DeepCollectionEquality().hash(chartData));
 
 @override
 String toString() {
-  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection)';
+  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection, chartData: $chartData)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SummaryStateCopyWith<$Res>  {
   factory $SummaryStateCopyWith(SummaryState value, $Res Function(SummaryState) _then) = _$SummaryStateCopyWithImpl;
 @useResult
 $Res call({
- Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection
+ Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection, List<Map<String, dynamic>> chartData
 });
 
 
@@ -62,14 +62,15 @@ class _$SummaryStateCopyWithImpl<$Res>
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,Object? chartData = null,}) {
   return _then(_self.copyWith(
 totalDrunk: null == totalDrunk ? _self.totalDrunk : totalDrunk // ignore: cast_nullable_to_non_nullable
 as Water,dailyAverage: null == dailyAverage ? _self.dailyAverage : dailyAverage // ignore: cast_nullable_to_non_nullable
 as Water,streak: null == streak ? _self.streak : streak // ignore: cast_nullable_to_non_nullable
 as int,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
 as UnitSystem,chartSelection: null == chartSelection ? _self.chartSelection : chartSelection // ignore: cast_nullable_to_non_nullable
-as ChartSelection,
+as ChartSelection,chartData: null == chartData ? _self.chartData : chartData // ignore: cast_nullable_to_non_nullable
+as List<Map<String, dynamic>>,
   ));
 }
 
@@ -154,10 +155,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection,  List<Map<String, dynamic>> chartData)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SummaryState() when $default != null:
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection,_that.chartData);case _:
   return orElse();
 
 }
@@ -175,10 +176,10 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection,  List<Map<String, dynamic>> chartData)  $default,) {final _that = this;
 switch (_that) {
 case _SummaryState():
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection,_that.chartData);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -195,10 +196,10 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Water totalDrunk,  Water dailyAverage,  int streak,  UnitSystem unitSystem,  ChartSelection chartSelection,  List<Map<String, dynamic>> chartData)?  $default,) {final _that = this;
 switch (_that) {
 case _SummaryState() when $default != null:
-return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection);case _:
+return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSystem,_that.chartSelection,_that.chartData);case _:
   return null;
 
 }
@@ -210,7 +211,7 @@ return $default(_that.totalDrunk,_that.dailyAverage,_that.streak,_that.unitSyste
 
 
 class _SummaryState implements SummaryState {
-  const _SummaryState({this.totalDrunk = const Water.zero(), this.dailyAverage = const Water.zero(), this.streak = 0, this.unitSystem = UnitSystem.metric, this.chartSelection = ChartSelection.weekly});
+  const _SummaryState({this.totalDrunk = const Water.zero(), this.dailyAverage = const Water.zero(), this.streak = 0, this.unitSystem = UnitSystem.metric, this.chartSelection = ChartSelection.weekly, required final  List<Map<String, dynamic>> chartData}): _chartData = chartData;
   
 
 @override@JsonKey() final  Water totalDrunk;
@@ -218,6 +219,13 @@ class _SummaryState implements SummaryState {
 @override@JsonKey() final  int streak;
 @override@JsonKey() final  UnitSystem unitSystem;
 @override@JsonKey() final  ChartSelection chartSelection;
+ final  List<Map<String, dynamic>> _chartData;
+@override List<Map<String, dynamic>> get chartData {
+  if (_chartData is EqualUnmodifiableListView) return _chartData;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_chartData);
+}
+
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
@@ -229,16 +237,16 @@ _$SummaryStateCopyWith<_SummaryState> get copyWith => __$SummaryStateCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SummaryState&&(identical(other.totalDrunk, totalDrunk) || other.totalDrunk == totalDrunk)&&(identical(other.dailyAverage, dailyAverage) || other.dailyAverage == dailyAverage)&&(identical(other.streak, streak) || other.streak == streak)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem)&&(identical(other.chartSelection, chartSelection) || other.chartSelection == chartSelection)&&const DeepCollectionEquality().equals(other._chartData, _chartData));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection);
+int get hashCode => Object.hash(runtimeType,totalDrunk,dailyAverage,streak,unitSystem,chartSelection,const DeepCollectionEquality().hash(_chartData));
 
 @override
 String toString() {
-  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection)';
+  return 'SummaryState(totalDrunk: $totalDrunk, dailyAverage: $dailyAverage, streak: $streak, unitSystem: $unitSystem, chartSelection: $chartSelection, chartData: $chartData)';
 }
 
 
@@ -249,7 +257,7 @@ abstract mixin class _$SummaryStateCopyWith<$Res> implements $SummaryStateCopyWi
   factory _$SummaryStateCopyWith(_SummaryState value, $Res Function(_SummaryState) _then) = __$SummaryStateCopyWithImpl;
 @override @useResult
 $Res call({
- Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection
+ Water totalDrunk, Water dailyAverage, int streak, UnitSystem unitSystem, ChartSelection chartSelection, List<Map<String, dynamic>> chartData
 });
 
 
@@ -266,14 +274,15 @@ class __$SummaryStateCopyWithImpl<$Res>
 
 /// Create a copy of SummaryState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? totalDrunk = null,Object? dailyAverage = null,Object? streak = null,Object? unitSystem = null,Object? chartSelection = null,Object? chartData = null,}) {
   return _then(_SummaryState(
 totalDrunk: null == totalDrunk ? _self.totalDrunk : totalDrunk // ignore: cast_nullable_to_non_nullable
 as Water,dailyAverage: null == dailyAverage ? _self.dailyAverage : dailyAverage // ignore: cast_nullable_to_non_nullable
 as Water,streak: null == streak ? _self.streak : streak // ignore: cast_nullable_to_non_nullable
 as int,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
 as UnitSystem,chartSelection: null == chartSelection ? _self.chartSelection : chartSelection // ignore: cast_nullable_to_non_nullable
-as ChartSelection,
+as ChartSelection,chartData: null == chartData ? _self._chartData : chartData // ignore: cast_nullable_to_non_nullable
+as List<Map<String, dynamic>>,
   ));
 }
 

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -47,7 +47,7 @@ class SummaryChart extends StatelessWidget {
                 ),
                 'amount': Variable(
                   accessor: (data) => (data as Map)['amount'] as num,
-                  scale: LinearScale(min: 0),
+                  scale: LinearScale(tickCount: 3, marginMax: 0),
                 ),
               },
               marks: [

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:graphic/graphic.dart';
+
+class SummaryChart extends StatelessWidget {
+  const SummaryChart({
+    super.key,
+    required this.data,
+  });
+
+  final List<dynamic> data;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 300,
+      width: 600,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainer,
+          borderRadius: BorderRadius.circular(24.0)
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 140),
+            transitionBuilder: (Widget child, Animation<double> animation) {
+              return FadeTransition(
+                opacity: animation,
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: const Offset(0, 0),
+                    end: Offset.zero,
+                  ).animate(CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeInOut,
+                  )),
+                  child: child,
+                ),
+              );
+            },
+            child: Chart(
+              key: ValueKey(data.length),
+              data: data,
+              variables: {
+                'period': Variable(
+                  accessor: (Map map) => map['period'] as String,
+                ),
+                'amount': Variable(
+                  accessor: (Map map) => map['amount'] as num,
+                ),
+              },
+              marks: [
+                IntervalMark(
+                  color: ColorEncode(
+                    value: Theme.of(context).colorScheme.primary),
+                    shape: ShapeEncode(value: RectShape(borderRadius: BorderRadius.circular(24))
+                  ),
+                ),
+              ],
+              axes: [
+                Defaults.horizontalAxis,
+                Defaults.verticalAxis,
+              ],
+            ),
+          ),
+        ),
+      )
+    );
+  }
+}

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -47,7 +47,7 @@ class SummaryChart extends StatelessWidget {
                 ),
                 'amount': Variable(
                   accessor: (data) => (data as Map)['amount'] as num,
-                  scale: LinearScale(tickCount: 3, marginMax: 0),
+                  scale: LinearScale(tickCount: 3, min: 0, marginMax: 0),
                 ),
               },
               marks: [
@@ -55,6 +55,10 @@ class SummaryChart extends StatelessWidget {
                   color: ColorEncode(
                     value: Theme.of(context).colorScheme.primary),
                     shape: ShapeEncode(value: RectShape(borderRadius: BorderRadius.circular(24))
+                  ),
+                  transition: Transition(
+                    duration: const Duration(milliseconds: 500),
+                    curve: Curves.easeIn,
                   ),
                 ),
               ],

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -43,10 +43,10 @@ class SummaryChart extends StatelessWidget {
               data: data,
               variables: {
                 'period': Variable(
-                  accessor: (Map map) => map['period'] as String,
+                  accessor: (data) => (data as Map)['period'] as String,
                 ),
                 'amount': Variable(
-                  accessor: (Map map) => map['amount'] as num,
+                  accessor: (data) => (data as Map)['amount'] as num,
                 ),
               },
               marks: [

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -39,7 +39,7 @@ class SummaryChart extends StatelessWidget {
               );
             },
             child: Chart(
-              key: ValueKey(data.length),
+              key: ValueKey(data.hashCode),
               data: data,
               variables: {
                 'period': Variable(

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -20,7 +20,7 @@ class SummaryChart extends StatelessWidget {
           borderRadius: BorderRadius.circular(24.0)
         ),
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(24.0),
           child: AnimatedSwitcher(
             duration: const Duration(milliseconds: 140),
             transitionBuilder: (Widget child, Animation<double> animation) {
@@ -58,8 +58,24 @@ class SummaryChart extends StatelessWidget {
                 ),
               ],
               axes: [
-                Defaults.horizontalAxis,
-                Defaults.verticalAxis,
+                AxisGuide(
+                  line: PaintStyle(
+                    strokeColor: Theme.of(context).colorScheme.onSurface
+                  ),
+                  label: LabelStyle(
+                    textStyle: TextStyle(color: Theme.of(context).textTheme.labelLarge!.color, fontSize: 12),
+                    offset: Offset(0, 8)
+                  ),
+                ),
+                AxisGuide(
+                  label: LabelStyle(
+                    textStyle: TextStyle(color: Theme.of(context).textTheme.labelLarge!.color, fontSize: 12),
+                    offset: Offset(-8, 0)
+                  ),
+                  grid: PaintStyle(
+                    strokeColor: Colors.white.withAlpha(60),
+                  )
+                ),
               ],
             ),
           ),

--- a/lib/features/summary/ui/view/components/summary_chart.dart
+++ b/lib/features/summary/ui/view/components/summary_chart.dart
@@ -47,6 +47,7 @@ class SummaryChart extends StatelessWidget {
                 ),
                 'amount': Variable(
                   accessor: (data) => (data as Map)['amount'] as num,
+                  scale: LinearScale(min: 0),
                 ),
               },
               marks: [

--- a/lib/features/summary/ui/view/summary_view.dart
+++ b/lib/features/summary/ui/view/summary_view.dart
@@ -76,6 +76,8 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
                   },
                   selected: {data.chartSelection},
                 ),
+
+
               ],
             ),
           ),

--- a/lib/features/summary/ui/view/summary_view.dart
+++ b/lib/features/summary/ui/view/summary_view.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
+import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 import 'package:hidroly/features/summary/ui/view_model/summary_view_model.dart';
 
 class SummaryView extends ConsumerStatefulWidget {
@@ -29,7 +30,7 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
             padding: const EdgeInsets.all(18.0),
             child: Column(
               spacing: 12,
-              crossAxisAlignment: .start,
+              crossAxisAlignment: .center,
               children: [
                 ListTile(
                   leading: CircleAvatar(child: Icon(Icons.local_drink)),
@@ -51,6 +52,29 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
                   subtitle: Text('day'.plural(data.streak)),
                   shape: RoundedRectangleBorder(borderRadius: BorderRadiusGeometry.circular(24)),
                   tileColor: Theme.of(context).colorScheme.surfaceContainer,
+                ),
+
+                SizedBox(height: 24,),
+                SegmentedButton(
+                  segments: [
+                    ButtonSegment(
+                      value: ChartSelection.weekly,
+                      label: Text('Weekly')
+                    ),
+                    ButtonSegment(
+                      value: ChartSelection.monthly,
+                      label: Text('Monthly')
+                    ),
+                    ButtonSegment(
+                      value: ChartSelection.yearly,
+                      label: Text('Yearly')
+                    ),
+                  ], 
+                  onSelectionChanged: (chartSelection) {
+                    ref.read(summaryViewModelProvider.notifier)
+                      .updateChartSelection(chartSelection.first);
+                  },
+                  selected: {data.chartSelection},
                 ),
               ],
             ),

--- a/lib/features/summary/ui/view/summary_view.dart
+++ b/lib/features/summary/ui/view/summary_view.dart
@@ -85,7 +85,7 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
         ),
       ),
       error: (_, _) => const Placeholder(),
-      loading: () => CircularProgressIndicator(),
+      loading: () => Center(child: CircularProgressIndicator(),),
     );
   }
 }

--- a/lib/features/summary/ui/view/summary_view.dart
+++ b/lib/features/summary/ui/view/summary_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
 import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
+import 'package:hidroly/features/summary/ui/view/components/summary_chart.dart';
 import 'package:hidroly/features/summary/ui/view_model/summary_view_model.dart';
 
 class SummaryView extends ConsumerStatefulWidget {
@@ -77,7 +78,7 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
                   selected: {data.chartSelection},
                 ),
 
-
+                SummaryChart(data: data.chartData)
               ],
             ),
           ),

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_daily_average_usecase.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_streak_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_total_drunk_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart';
@@ -34,8 +35,21 @@ class SummaryViewModel extends _$SummaryViewModel {
   }
 
   void updateChartSelection(ChartSelection chartSelection) async {
-    state = state.whenData((currentState) {
-      return currentState.copyWith(chartSelection: chartSelection);
+    state = await AsyncValue.guard(() async {
+      final currentState = state.requireValue;
+      List<Map<String, dynamic>> chartData;
+
+      switch(chartSelection) {
+        case .monthly:
+          chartData = await ref.read(getMonthlyChartDataUseCaseProvider).execute();
+          break;
+        default: chartData = await ref.read(getWeeklyChartDataUseCaseProvider).execute();
+      }
+
+      return currentState.copyWith(
+        chartSelection: chartSelection,
+        chartData: chartData,
+      );
     });
   }
 }

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -16,15 +16,17 @@ part 'summary_view_model.g.dart';
 class SummaryViewModel extends _$SummaryViewModel {
   @override
   Future<SummaryState> build() async {
-    final (totalDrunk, dailyAverage, streak, weeklyChartData) = await (
+    final (totalDrunk, dailyAverage, streak) = await (
       ref.read(getTotalDrunkUseCaseProvider).execute(),
       ref.read(getDailyAverageUseCaseProvider).execute(),
       ref.read(getStreakUseCaseProvider).execute(),
-      ref.read(getWeeklyChartDataUseCaseProvider).execute(),
     ).wait;
 
     final unitSystem = 
       await ref.watch(settingsRepositoryProvider).readUnitSystem();
+    
+    final weeklyChartData = 
+      await ref.read(getWeeklyChartDataUseCaseProvider).execute(unitSystem);
     
     return SummaryState(
       totalDrunk: Water.ml(totalDrunk),
@@ -38,17 +40,19 @@ class SummaryViewModel extends _$SummaryViewModel {
   void updateChartSelection(ChartSelection chartSelection) async {
     state = await AsyncValue.guard(() async {
       final currentState = state.requireValue;
+      final unitSystem = currentState.unitSystem;
+
       List<Map<String, dynamic>> chartData;
 
       switch(chartSelection) {
         case .monthly:
-          chartData = await ref.read(getMonthlyChartDataUseCaseProvider).execute();
+          chartData = await ref.read(getMonthlyChartDataUseCaseProvider).execute(unitSystem);
           break;
         case .yearly:
-          chartData = await ref.read(getYearlyChartDataUsecaseProvider).execute();
+          chartData = await ref.read(getYearlyChartDataUsecaseProvider).execute(unitSystem);
           break;
         default: 
-          chartData = await ref.read(getWeeklyChartDataUseCaseProvider).execute();
+          chartData = await ref.read(getWeeklyChartDataUseCaseProvider).execute(unitSystem);
       }
 
       return currentState.copyWith(

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -5,6 +5,7 @@ import 'package:hidroly/features/summary/domain/usecases/get_monthly_chart_data_
 import 'package:hidroly/features/summary/domain/usecases/get_streak_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_total_drunk_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart';
 import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 import 'package:hidroly/features/summary/ui/state/summary_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -43,7 +44,11 @@ class SummaryViewModel extends _$SummaryViewModel {
         case .monthly:
           chartData = await ref.read(getMonthlyChartDataUseCaseProvider).execute();
           break;
-        default: chartData = await ref.read(getWeeklyChartDataUseCaseProvider).execute();
+        case .yearly:
+          chartData = await ref.read(getYearlyChartDataUsecaseProvider).execute();
+          break;
+        default: 
+          chartData = await ref.read(getWeeklyChartDataUseCaseProvider).execute();
       }
 
       return currentState.copyWith(

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -3,6 +3,7 @@ import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_daily_average_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_streak_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_total_drunk_usecase.dart';
+import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 import 'package:hidroly/features/summary/ui/state/summary_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -27,5 +28,11 @@ class SummaryViewModel extends _$SummaryViewModel {
       streak: results[2],
       unitSystem: unitSystem,
     );
+  }
+
+  void updateChartSelection(ChartSelection chartSelection) async {
+    state = state.whenData((currentState) {
+      return currentState.copyWith(chartSelection: chartSelection);
+    });
   }
 }

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -3,6 +3,7 @@ import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_daily_average_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_streak_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_total_drunk_usecase.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart';
 import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 import 'package:hidroly/features/summary/ui/state/summary_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -13,20 +14,22 @@ part 'summary_view_model.g.dart';
 class SummaryViewModel extends _$SummaryViewModel {
   @override
   Future<SummaryState> build() async {
-    final results = await Future.wait([
+    final (totalDrunk, dailyAverage, streak, weeklyChartData) = await (
       ref.read(getTotalDrunkUseCaseProvider).execute(),
       ref.read(getDailyAverageUseCaseProvider).execute(),
       ref.read(getStreakUseCaseProvider).execute(),
-    ]);
+      ref.read(getWeeklyChartDataUseCaseProvider).execute(),
+    ).wait;
 
     final unitSystem = 
       await ref.watch(settingsRepositoryProvider).readUnitSystem();
     
     return SummaryState(
-      totalDrunk: Water.ml(results[0]),
-      dailyAverage: Water.ml(results[1]),
-      streak: results[2],
+      totalDrunk: Water.ml(totalDrunk),
+      dailyAverage: Water.ml(dailyAverage),
+      streak: streak,
       unitSystem: unitSystem,
+      chartData: weeklyChartData,
     );
   }
 

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'73dce19b88850243b64e53f916e7c925cc516be1';
+String _$summaryViewModelHash() => r'd3bcadb19d72f2f2bf4ac9a1b75d12e958470770';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'd3bcadb19d72f2f2bf4ac9a1b75d12e958470770';
+String _$summaryViewModelHash() => r'4eb6c0374791f2f47de5bc032c8f39be1f12cd2b';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'4eb6c0374791f2f47de5bc032c8f39be1f12cd2b';
+String _$summaryViewModelHash() => r'b2971dd1ba139c160965ecb806153ba00c85049c';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'00588b2e0a56721ee9e7e0649ec704a274f49fb2';
+String _$summaryViewModelHash() => r'73dce19b88850243b64e53f916e7c925cc516be1';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'b2971dd1ba139c160965ecb806153ba00c85049c';
+String _$summaryViewModelHash() => r'5e3c0931f4099867833a4481accc58464f114095';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,7 +162,7 @@ packages:
     source: hosted
     version: "4.11.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.2.0"
+  graphic:
+    dependency: "direct main"
+    description:
+      name: graphic
+      sha256: f0028af737f7fdd5fd50c043af85242d72638ae040a820470208bc885a229d04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   graphs:
     dependency: transitive
     description:
@@ -549,6 +557,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   freezed: ^3.2.5
   freezed_annotation: ^3.1.0
   go_router: ^17.1.0
+  graphic: ^2.7.0
   mocktail: ^1.0.4
   path_provider: ^2.1.5
   result_dart: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
+  collection: ^1.19.1
   drift: ^2.31.0
   drift_flutter: ^0.2.8
   easy_localization: ^3.0.8

--- a/test/features/summary/domain/usecases/get_monthly_chart_data_usecase_test.dart
+++ b/test/features/summary/domain/usecases/get_monthly_chart_data_usecase_test.dart
@@ -1,0 +1,124 @@
+import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../../../testing/repositories/mock_day_repository.dart';
+
+void main() {
+  late DayRepository dayRepository;
+  late GetMonthlyChartDataUsecase useCase;
+
+  setUp(() {
+    dayRepository = MockDayRepository();
+    useCase = GetMonthlyChartDataUsecase(dayRepository);
+  });
+
+  group('Get monthly chart data usecase tests', () {
+    test(('Should group correctly by week'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final monthlyMap = await useCase.execute(UnitSystem.metric);
+      expect(monthlyMap[0]['period'], '1');
+    });
+
+    test('Should group correctly when there are multiple weeks', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 7),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 8),
+        ),
+      ]);
+
+      final monthlyMap = await useCase.execute(UnitSystem.metric);
+
+      expect(monthlyMap.length, 2);
+      expect(monthlyMap[0]['period'], '1');
+      expect(monthlyMap[1]['period'], '2');
+    });
+
+    test('Should skip week if it doesn\'t have data', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 15),
+        ),
+      ]);
+
+      final monthlyMap = await useCase.execute(UnitSystem.metric);
+
+      expect(monthlyMap.length, 2);
+      expect(monthlyMap[0]['period'], '1');
+      expect(monthlyMap[1]['period'], '3');
+    });
+
+    test('Should return the sum of all days in a week', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final monthlyMap = await useCase.execute(UnitSystem.metric);
+      final amount = Water.ml(monthlyMap[0]['amount']);
+
+      expect(amount.ml, 600);
+    });
+
+    test('Should return correct oz value', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final monthlyMap = await useCase.execute(UnitSystem.imperial);
+      final amount = monthlyMap[0]['amount'];
+
+      final oz = (600 / 29.574).round();
+      expect(amount, oz);
+    });
+  });
+}

--- a/test/features/summary/domain/usecases/get_weekly_chart_data_usecase_test.dart
+++ b/test/features/summary/domain/usecases/get_weekly_chart_data_usecase_test.dart
@@ -1,0 +1,99 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_weekly_chart_data_usecase.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../../../testing/repositories/mock_day_repository.dart';
+
+void main() {
+  late DayRepository dayRepository;
+  late GetWeeklyChartDataUseCase useCase;
+
+  setUp(() {
+    dayRepository = MockDayRepository();
+    useCase = GetWeeklyChartDataUseCase(dayRepository);
+  });
+
+  group('Get weekly chart data usecase tests', () {
+    test(('Should group correctly by day'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final daysMap = await useCase.execute(UnitSystem.metric);
+
+      expect(daysMap[0]['period'], DateFormat.E().format(DateTime(2026, 1, 1)));
+      expect(daysMap[1]['period'], DateFormat.E().format(DateTime(2026, 1, 2)));
+    });
+
+    test(('Should get correct amount for each day'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.zero(),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.zero(),
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final daysMap = await useCase.execute(UnitSystem.metric);
+
+      expect(daysMap[0]['amount'], Water.zero().ml);
+      expect(daysMap[1]['amount'], Water.zero().ml);
+    });
+
+    test(('Should ignore data from past week'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => []);
+
+      await useCase.execute(UnitSystem.metric, baseDate: DateTime(2026, 1, 7));
+
+      verify(() => dayRepository.readByRange(
+        DateTime(2026, 1, 4), 
+        DateTime(2026, 1, 7),
+      )).called(1);
+    });
+  
+    test(('Should not break on january 1'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => []);
+
+      await useCase.execute(UnitSystem.metric, baseDate: DateTime(2026, 1, 1));
+
+      verify(() => dayRepository.readByRange(
+        DateTime(2025, 12, 28), 
+        DateTime(2026, 1, 1),
+      )).called(1);
+    });
+
+    test(('Should convert to oz'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+      ]);
+
+      final daysMap = await useCase.execute(UnitSystem.imperial);
+
+      final amount = daysMap[0]['amount'];
+      final oz = (300 / 29.574).round();
+
+      expect(amount, oz);
+    });
+  });
+}

--- a/test/features/summary/domain/usecases/get_yearly_chart_data_usecase_test.dart
+++ b/test/features/summary/domain/usecases/get_yearly_chart_data_usecase_test.dart
@@ -1,0 +1,115 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:hidroly/core/domain/entities/day.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+import 'package:hidroly/core/domain/repositories/day_repository.dart';
+import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
+import 'package:hidroly/features/summary/domain/usecases/get_yearly_chart_data_usecase.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../../../testing/repositories/mock_day_repository.dart';
+
+void main() {
+  late DayRepository dayRepository;
+  late GetYearlyChartDataUsecase useCase;
+
+  setUp(() {
+    dayRepository = MockDayRepository();
+    useCase = GetYearlyChartDataUsecase(dayRepository);
+  });
+
+  group('Get Yearly chart data usecase tests', () {
+    test(('Should group correctly by month'), () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final yearlyMap = await useCase.execute(UnitSystem.metric);
+      expect(yearlyMap[0]['period'], DateFormat.LLL().format(DateTime(2026, 1, 1)));
+    });
+
+    test('Should group correctly when there are multiple months', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 2, 1),
+        ),
+      ]);
+
+      final yearlyMap = await useCase.execute(UnitSystem.metric);
+      expect(yearlyMap[0]['period'], DateFormat.LLL().format(DateTime(2026, 1, 1)));
+      expect(yearlyMap[1]['period'], DateFormat.LLL().format(DateTime(2026, 2, 1)));
+    });
+
+    test('Should only return months that have data', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 1, 2),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          createdAt: DateTime(2026, 3, 1),
+        ),
+      ]);
+
+      final yearlyMap = await useCase.execute(UnitSystem.metric);
+
+      expect(yearlyMap.length, 2);
+      expect(yearlyMap[0]['period'], DateFormat.LLL().format(DateTime(2026, 1, 1)));
+      expect(yearlyMap[1]['period'], DateFormat.LLL().format(DateTime(2026, 3, 1)));
+    });
+
+    test('Should return the sum of all days in a month', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final yearlyMap = await useCase.execute(UnitSystem.metric);
+      final amount = Water.ml(yearlyMap[0]['amount']);
+
+      expect(amount.ml, 600);
+    });
+
+    test('Should return correct oz value', () async {
+      when(() => dayRepository.readByRange(any(), any())).thenAnswer((_) async => [
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        Day(
+          dailyGoal: Water.zero(), 
+          currentAmount: Water.ml(300),
+          createdAt: DateTime(2026, 1, 2),
+        ),
+      ]);
+
+      final yearlyMap = await useCase.execute(UnitSystem.imperial);
+      final amount = yearlyMap[0]['amount'];
+
+      final oz = (600 / 29.574).round();
+      expect(amount, oz);
+    });
+  });
+}


### PR DESCRIPTION
# Description
This PR implements the summary page chart with support for weekly, monthly, and yearly data using the `Graphic` package.

## Key Changes:
* Logic: Added UseCases to handle data grouping and unit conversion (Metric/Imperial).
* State: Chart data is managed within the summary state and view model.

## Testing Status
* UseCases fully tested, covering date ranges, unit conversions and year-turnover logic.