### PR TITLE
feat: settings

### DIFF
--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -43,5 +43,9 @@
     },
     "weekly": "Weekly",
     "monthly": "Monthly",
-    "yearly": "Yearly"
+    "yearly": "Yearly",
+    "theme": "Theme",
+    "system": "System",
+    "light": "Light",
+    "dark": "Dark"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -44,6 +44,7 @@
     "weekly": "Weekly",
     "monthly": "Monthly",
     "yearly": "Yearly",
+    "settings": "Settings",
     "theme": "Theme",
     "system": "System",
     "light": "Light",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -47,5 +47,8 @@
     "theme": "Theme",
     "system": "System",
     "light": "Light",
-    "dark": "Dark"
+    "dark": "Dark",
+    "unitSystem": "Unit System",
+    "metric": "Metric (ml, kg)",
+    "imperial": "Imperial (lb, oz)"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -50,5 +50,6 @@
     "dark": "Dark",
     "unitSystem": "Unit System",
     "metric": "Metric (ml, kg)",
-    "imperial": "Imperial (lb, oz)"
+    "imperial": "Imperial (lb, oz)",
+    "buyMeACoffee": "Buy me a coffee"
 }

--- a/lib/core/data/repositories/settings_repository_impl.dart
+++ b/lib/core/data/repositories/settings_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/repositories/settings_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,6 +15,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
   final sharedPreferences = SharedPreferencesAsync();
 
   final unitSystemKey = 'unitSystem';
+  final themeKey = 'theme';
 
   @override
   Future<void> saveUnitSystem(UnitSystem unitSystem) async {
@@ -21,8 +23,19 @@ class SettingsRepositoryImpl implements SettingsRepository {
   }
 
   @override
+  Future<void> saveTheme(ThemeMode theme) async {
+    await sharedPreferences.setInt(themeKey, theme.index);
+  }
+
+  @override
   Future<UnitSystem> readUnitSystem() async {
     final index = await sharedPreferences.getInt(unitSystemKey) ?? 0;
     return UnitSystem.values[index];
+  }
+
+  @override
+  Future<ThemeMode> readTheme() async {
+    final index = await sharedPreferences.getInt(themeKey) ?? 0;
+    return ThemeMode.values[index];
   }
 }

--- a/lib/core/domain/repositories/settings_repository.dart
+++ b/lib/core/domain/repositories/settings_repository.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 
 abstract class SettingsRepository {
   Future<void> saveUnitSystem(UnitSystem unitSystem);
+  Future<void> saveTheme(ThemeMode theme);
   Future<UnitSystem> readUnitSystem();
+  Future<ThemeMode> readTheme();
 }

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -2,6 +2,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/features/home/ui/view/home_view.dart';
 import 'package:hidroly/features/hydration/ui/view/hydration_view.dart';
+import 'package:hidroly/features/settings/ui/view/settings_view.dart';
 import 'package:hidroly/features/setup/ui/view/setup_view.dart';
 import 'package:hidroly/features/summary/ui/view/summary_view.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -29,6 +30,7 @@ GoRouter router(Ref ref) {
     },
     routes: [
       GoRoute(path: '/setup', builder: (_, _) => SetupView()),
+      GoRoute(path: '/settings', builder: (_, _) => SettingsView()),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) => HomeView(navigationShell: navigationShell),
         branches: [

--- a/lib/core/navigation/app_routes.g.dart
+++ b/lib/core/navigation/app_routes.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'71215f4e728073ac42a0e86626167d5e9db37d13';
+String _$routerHash() => r'c2fd17e6f868cfb49ef3f51ee2895db7df056c14';

--- a/lib/core/providers/theme_provider.dart
+++ b/lib/core/providers/theme_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'theme_provider.g.dart';
+
+@riverpod
+class ThemeProvider extends _$ThemeProvider {
+  @override
+  Future<ThemeMode> build() {
+    return ref.watch(settingsRepositoryProvider).readTheme();
+  }
+
+  void setTheme(ThemeMode theme) {
+    ref.read(settingsRepositoryProvider).saveTheme(theme);
+    state = AsyncValue.data(theme);
+  }
+}

--- a/lib/core/providers/theme_provider.g.dart
+++ b/lib/core/providers/theme_provider.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ThemeProvider)
+final themeProviderProvider = ThemeProviderProvider._();
+
+final class ThemeProviderProvider
+    extends $AsyncNotifierProvider<ThemeProvider, ThemeMode> {
+  ThemeProviderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'themeProviderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$themeProviderHash();
+
+  @$internal
+  @override
+  ThemeProvider create() => ThemeProvider();
+}
+
+String _$themeProviderHash() => r'daa82305dfece479327b82b3fc299f4a34294ae3';
+
+abstract class _$ThemeProvider extends $AsyncNotifier<ThemeMode> {
+  FutureOr<ThemeMode> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<ThemeMode>, ThemeMode>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<ThemeMode>, ThemeMode>,
+              AsyncValue<ThemeMode>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/providers/unit_system_provider.dart
+++ b/lib/core/providers/unit_system_provider.dart
@@ -1,0 +1,18 @@
+import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'unit_system_provider.g.dart';
+
+@riverpod
+class UnitSystemProvider extends _$UnitSystemProvider {
+  @override
+  Future<UnitSystem> build() {
+    return ref.watch(settingsRepositoryProvider).readUnitSystem();
+  }
+
+  void setUnitSystem(UnitSystem unitSystem) {
+    ref.read(settingsRepositoryProvider).saveUnitSystem(unitSystem);
+    state = AsyncValue.data(unitSystem);
+  }
+}

--- a/lib/core/providers/unit_system_provider.g.dart
+++ b/lib/core/providers/unit_system_provider.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'unit_system_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(UnitSystemProvider)
+final unitSystemProviderProvider = UnitSystemProviderProvider._();
+
+final class UnitSystemProviderProvider
+    extends $AsyncNotifierProvider<UnitSystemProvider, UnitSystem> {
+  UnitSystemProviderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'unitSystemProviderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$unitSystemProviderHash();
+
+  @$internal
+  @override
+  UnitSystemProvider create() => UnitSystemProvider();
+}
+
+String _$unitSystemProviderHash() =>
+    r'6fb5d11a2aec9c38d08fe70e915cecc1146b378d';
+
+abstract class _$UnitSystemProvider extends $AsyncNotifier<UnitSystem> {
+  FutureOr<UnitSystem> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<UnitSystem>, UnitSystem>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<UnitSystem>, UnitSystem>,
+              AsyncValue<UnitSystem>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/ui/extensions/unit_system_ui_extension.dart
+++ b/lib/core/ui/extensions/unit_system_ui_extension.dart
@@ -2,5 +2,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 
 extension UnitSystemUIX on UnitSystem {
+  String get label => this == UnitSystem.metric ? 'metric'.tr() : 'imperial'.tr();
   String get unitLabel => this == UnitSystem.metric ? 'ml'.tr() : 'oz'.tr();
 }

--- a/lib/features/hydration/ui/view/hydration_view.dart
+++ b/lib/features/hydration/ui/view/hydration_view.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hidroly/features/hydration/domain/value_objects/cup_value.dart';
 import 'package:hidroly/features/hydration/ui/extensions/date_time_formatting.dart';
 import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
@@ -58,6 +59,10 @@ class _HydrationViewState extends ConsumerState<HydrationView> {
             IconButton(
               onPressed: () => showModalBottomSheet(context: context, builder: (_) => HistoryModal()),
               icon: Icon(Icons.history),
+            ),
+            IconButton(
+              onPressed: () => context.push('/settings'),
+              icon: Icon(Icons.settings),
             ),
           ],
         ),

--- a/lib/features/hydration/ui/view_model/hydration_view_model.dart
+++ b/lib/features/hydration/ui/view_model/hydration_view_model.dart
@@ -1,5 +1,4 @@
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
-import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/domain/entities/day.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/exceptions/invalid_input_exception.dart';

--- a/lib/features/hydration/ui/view_model/hydration_view_model.dart
+++ b/lib/features/hydration/ui/view_model/hydration_view_model.dart
@@ -3,6 +3,7 @@ import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/domain/entities/day.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/exceptions/invalid_input_exception.dart';
+import 'package:hidroly/core/providers/unit_system_provider.dart';
 import 'package:hidroly/core/ui/enums/input_status.dart';
 import 'package:hidroly/features/hydration/data/repositories/cup_repository_impl.dart';
 import 'package:hidroly/features/hydration/data/repositories/history_item_repository_impl.dart';
@@ -24,12 +25,11 @@ class HydrationViewModel extends _$HydrationViewModel {
     final dayRepository = ref.watch(dayRepositoryProvider);
     final historyRepository = ref.watch(historyItemRepositoryProvider);
     final cupRepository = ref.watch(cupRepositoryProvider);
-    final settingsRepository = ref.watch(settingsRepositoryProvider);
+    final unitSystem = await ref.watch(unitSystemProviderProvider.future);
 
     final day = await dayRepository.readOrCreateByDate(selectedDate);
     final history = await historyRepository.readAll(day.id);
     final cups = await cupRepository.readAll();
-    final unitSystem = await settingsRepository.readUnitSystem();
 
     return HydrationState(day: day, history: history, unitSystem: unitSystem, cups: cups);
   }

--- a/lib/features/hydration/ui/view_model/hydration_view_model.g.dart
+++ b/lib/features/hydration/ui/view_model/hydration_view_model.g.dart
@@ -34,7 +34,7 @@ final class HydrationViewModelProvider
 }
 
 String _$hydrationViewModelHash() =>
-    r'020e14d3217c12b6f06741220d315c61f6714ab5';
+    r'ac933ad8d064d303ed9690fdbe5c12a97e6fa7dc';
 
 abstract class _$HydrationViewModel extends $AsyncNotifier<HydrationState> {
   FutureOr<HydrationState> build();

--- a/lib/features/settings/ui/extensions/theme_mode_ui_extension.dart
+++ b/lib/features/settings/ui/extensions/theme_mode_ui_extension.dart
@@ -1,0 +1,12 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+extension ThemeModeX on ThemeMode {
+  String label() {
+    switch(this) {
+      case .light: return 'light'.tr();
+      case .dark: return 'dark'.tr();
+      default: return 'system'.tr();
+    }
+  }
+}

--- a/lib/features/settings/ui/state/settings_state.dart
+++ b/lib/features/settings/ui/state/settings_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 
 part 'settings_state.freezed.dart';
 
@@ -7,5 +8,6 @@ part 'settings_state.freezed.dart';
 abstract class SettingsState with _$SettingsState {
   const factory SettingsState({
     @Default(ThemeMode.system) ThemeMode theme,
+    @Default(UnitSystem.metric) UnitSystem unitSystem,
   }) = _SettingsState; 
 }

--- a/lib/features/settings/ui/state/settings_state.dart
+++ b/lib/features/settings/ui/state/settings_state.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'settings_state.freezed.dart';
+
+@freezed
+abstract class SettingsState with _$SettingsState {
+  const factory SettingsState({
+    @Default(ThemeMode.system) ThemeMode theme,
+  }) = _SettingsState; 
+}

--- a/lib/features/settings/ui/state/settings_state.freezed.dart
+++ b/lib/features/settings/ui/state/settings_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SettingsState {
 
- ThemeMode get theme;
+ ThemeMode get theme; UnitSystem get unitSystem;
 /// Create a copy of SettingsState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SettingsStateCopyWith<SettingsState> get copyWith => _$SettingsStateCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsState&&(identical(other.theme, theme) || other.theme == theme));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsState&&(identical(other.theme, theme) || other.theme == theme)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,theme);
+int get hashCode => Object.hash(runtimeType,theme,unitSystem);
 
 @override
 String toString() {
-  return 'SettingsState(theme: $theme)';
+  return 'SettingsState(theme: $theme, unitSystem: $unitSystem)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SettingsStateCopyWith<$Res>  {
   factory $SettingsStateCopyWith(SettingsState value, $Res Function(SettingsState) _then) = _$SettingsStateCopyWithImpl;
 @useResult
 $Res call({
- ThemeMode theme
+ ThemeMode theme, UnitSystem unitSystem
 });
 
 
@@ -62,10 +62,11 @@ class _$SettingsStateCopyWithImpl<$Res>
 
 /// Create a copy of SettingsState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? theme = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? theme = null,Object? unitSystem = null,}) {
   return _then(_self.copyWith(
 theme: null == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
-as ThemeMode,
+as ThemeMode,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
+as UnitSystem,
   ));
 }
 
@@ -150,10 +151,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ThemeMode theme)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ThemeMode theme,  UnitSystem unitSystem)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SettingsState() when $default != null:
-return $default(_that.theme);case _:
+return $default(_that.theme,_that.unitSystem);case _:
   return orElse();
 
 }
@@ -171,10 +172,10 @@ return $default(_that.theme);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ThemeMode theme)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ThemeMode theme,  UnitSystem unitSystem)  $default,) {final _that = this;
 switch (_that) {
 case _SettingsState():
-return $default(_that.theme);case _:
+return $default(_that.theme,_that.unitSystem);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -191,10 +192,10 @@ return $default(_that.theme);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ThemeMode theme)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ThemeMode theme,  UnitSystem unitSystem)?  $default,) {final _that = this;
 switch (_that) {
 case _SettingsState() when $default != null:
-return $default(_that.theme);case _:
+return $default(_that.theme,_that.unitSystem);case _:
   return null;
 
 }
@@ -206,10 +207,11 @@ return $default(_that.theme);case _:
 
 
 class _SettingsState implements SettingsState {
-  const _SettingsState({this.theme = ThemeMode.system});
+  const _SettingsState({this.theme = ThemeMode.system, this.unitSystem = UnitSystem.metric});
   
 
 @override@JsonKey() final  ThemeMode theme;
+@override@JsonKey() final  UnitSystem unitSystem;
 
 /// Create a copy of SettingsState
 /// with the given fields replaced by the non-null parameter values.
@@ -221,16 +223,16 @@ _$SettingsStateCopyWith<_SettingsState> get copyWith => __$SettingsStateCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettingsState&&(identical(other.theme, theme) || other.theme == theme));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettingsState&&(identical(other.theme, theme) || other.theme == theme)&&(identical(other.unitSystem, unitSystem) || other.unitSystem == unitSystem));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,theme);
+int get hashCode => Object.hash(runtimeType,theme,unitSystem);
 
 @override
 String toString() {
-  return 'SettingsState(theme: $theme)';
+  return 'SettingsState(theme: $theme, unitSystem: $unitSystem)';
 }
 
 
@@ -241,7 +243,7 @@ abstract mixin class _$SettingsStateCopyWith<$Res> implements $SettingsStateCopy
   factory _$SettingsStateCopyWith(_SettingsState value, $Res Function(_SettingsState) _then) = __$SettingsStateCopyWithImpl;
 @override @useResult
 $Res call({
- ThemeMode theme
+ ThemeMode theme, UnitSystem unitSystem
 });
 
 
@@ -258,10 +260,11 @@ class __$SettingsStateCopyWithImpl<$Res>
 
 /// Create a copy of SettingsState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? theme = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? theme = null,Object? unitSystem = null,}) {
   return _then(_SettingsState(
 theme: null == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
-as ThemeMode,
+as ThemeMode,unitSystem: null == unitSystem ? _self.unitSystem : unitSystem // ignore: cast_nullable_to_non_nullable
+as UnitSystem,
   ));
 }
 

--- a/lib/features/settings/ui/state/settings_state.freezed.dart
+++ b/lib/features/settings/ui/state/settings_state.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'settings_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SettingsState {
+
+ ThemeMode get theme;
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SettingsStateCopyWith<SettingsState> get copyWith => _$SettingsStateCopyWithImpl<SettingsState>(this as SettingsState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsState&&(identical(other.theme, theme) || other.theme == theme));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,theme);
+
+@override
+String toString() {
+  return 'SettingsState(theme: $theme)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SettingsStateCopyWith<$Res>  {
+  factory $SettingsStateCopyWith(SettingsState value, $Res Function(SettingsState) _then) = _$SettingsStateCopyWithImpl;
+@useResult
+$Res call({
+ ThemeMode theme
+});
+
+
+
+
+}
+/// @nodoc
+class _$SettingsStateCopyWithImpl<$Res>
+    implements $SettingsStateCopyWith<$Res> {
+  _$SettingsStateCopyWithImpl(this._self, this._then);
+
+  final SettingsState _self;
+  final $Res Function(SettingsState) _then;
+
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? theme = null,}) {
+  return _then(_self.copyWith(
+theme: null == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
+as ThemeMode,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SettingsState].
+extension SettingsStatePatterns on SettingsState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SettingsState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SettingsState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SettingsState value)  $default,){
+final _that = this;
+switch (_that) {
+case _SettingsState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SettingsState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SettingsState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ThemeMode theme)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SettingsState() when $default != null:
+return $default(_that.theme);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ThemeMode theme)  $default,) {final _that = this;
+switch (_that) {
+case _SettingsState():
+return $default(_that.theme);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ThemeMode theme)?  $default,) {final _that = this;
+switch (_that) {
+case _SettingsState() when $default != null:
+return $default(_that.theme);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _SettingsState implements SettingsState {
+  const _SettingsState({this.theme = ThemeMode.system});
+  
+
+@override@JsonKey() final  ThemeMode theme;
+
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SettingsStateCopyWith<_SettingsState> get copyWith => __$SettingsStateCopyWithImpl<_SettingsState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettingsState&&(identical(other.theme, theme) || other.theme == theme));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,theme);
+
+@override
+String toString() {
+  return 'SettingsState(theme: $theme)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SettingsStateCopyWith<$Res> implements $SettingsStateCopyWith<$Res> {
+  factory _$SettingsStateCopyWith(_SettingsState value, $Res Function(_SettingsState) _then) = __$SettingsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ ThemeMode theme
+});
+
+
+
+
+}
+/// @nodoc
+class __$SettingsStateCopyWithImpl<$Res>
+    implements _$SettingsStateCopyWith<$Res> {
+  __$SettingsStateCopyWithImpl(this._self, this._then);
+
+  final _SettingsState _self;
+  final $Res Function(_SettingsState) _then;
+
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? theme = null,}) {
+  return _then(_SettingsState(
+theme: null == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
+as ThemeMode,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/settings/ui/view/components/general_section.dart
+++ b/lib/features/settings/ui/view/components/general_section.dart
@@ -1,0 +1,91 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
+import 'package:hidroly/features/settings/ui/extensions/theme_mode_ui_extension.dart';
+import 'package:hidroly/features/settings/ui/state/settings_state.dart';
+import 'package:hidroly/features/settings/ui/view_model/settings_view_model.dart';
+
+class SettingsGeneralSection extends ConsumerWidget {
+  const SettingsGeneralSection({
+    super.key,
+    required this.data,
+  });
+
+  final SettingsState data;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Card(
+      child: Column(
+        children: [
+          ListTile(
+            leading: CircleAvatar(child: Icon(Icons.style),),
+            title: Text('theme'.tr()),
+            subtitle: Text(data.theme.label()),
+            trailing: MenuAnchor(
+              controller: MenuController(),
+              menuChildren: <MenuItemButton>[
+                MenuItemButton(
+                  child: Text('system'.tr()),
+                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.system),
+                ),
+                MenuItemButton(
+                  child: Text('light'.tr()),
+                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.light),
+                ),
+                MenuItemButton(
+                  child: Text('dark'.tr()),
+                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.dark),
+                ),
+              ],
+              builder: (_, controller, _) {
+                return IconButton(
+                  onPressed: () {
+                    controller.isOpen
+                    ? controller.close()
+                    : controller.open();
+                  }, 
+                  icon: controller.isOpen
+                    ? Icon(Icons.arrow_drop_up)
+                    : Icon(Icons.arrow_drop_down),
+                );
+              },
+            ),
+          ),
+          ListTile(
+            title: Text('unitSystem'.tr()),
+            subtitle: Text(data.unitSystem.label),
+            leading: CircleAvatar(child: Icon(Icons.straighten),),
+            trailing: MenuAnchor(
+              controller: MenuController(),
+              menuChildren: <MenuItemButton>[
+                MenuItemButton(
+                  child: Text('metric'.tr()),
+                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.metric),
+                ),
+                MenuItemButton(
+                  child: Text('imperial'.tr()),
+                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.imperial),
+                ),
+              ],
+              builder: (_, controller, _) {
+                return IconButton(
+                  onPressed: () {
+                    controller.isOpen
+                    ? controller.close()
+                    : controller.open();
+                  }, 
+                  icon: controller.isOpen
+                    ? Icon(Icons.arrow_drop_up)
+                    : Icon(Icons.arrow_drop_down),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+class SettingsView extends StatelessWidget {
+  const SettingsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Settings'),
+      ),
+      body: SafeArea(
+        minimum: EdgeInsets.all(16),
+        child: Column(
+          spacing: 6,
+          mainAxisAlignment: .center,
+          crossAxisAlignment: .start,
+          children: [
+            Center(
+              child: Column(
+                spacing: 4,
+                children: [
+                  Text(
+                    'Hidroly', 
+                    style: Theme.of(context).textTheme.headlineLarge!.copyWith(fontWeight: .bold),
+                    textAlign: .center,
+                  ),
+                  ElevatedButton.icon(
+                    onPressed: () {}, 
+                    label: Text('Buy me a coffee'),
+                    icon: Icon(Icons.favorite),
+                  ),
+                ],
+              ),
+            ),
+            
+            SizedBox(height: 24,),
+
+            Card(
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: CircleAvatar(child: Icon(Icons.style),),
+                    title: Text('Theme'),
+                    subtitle: Text('System'),
+                    trailing: MenuAnchor(
+                      controller: MenuController(),
+                      menuChildren: <MenuItemButton>[
+                        MenuItemButton(
+                          child: Text('System'),
+                          onPressed: () {},
+                        ),
+                        MenuItemButton(
+                          child: Text('Light'),
+                          onPressed: () {},
+                        ),
+                        MenuItemButton(
+                          child: Text('Dark'),
+                          onPressed: () {},
+                        ),
+                      ],
+                      builder: (_, controller, _) {
+                        return IconButton(
+                          onPressed: () {
+                            controller.isOpen
+                            ? controller.close()
+                            : controller.open();
+                          }, 
+                          icon: controller.isOpen
+                            ? Icon(Icons.arrow_drop_up)
+                            : Icon(Icons.arrow_drop_down),
+                        );
+                      },
+                    ),
+                  ),
+                  ListTile(
+                    title: Text('Language'),
+                    subtitle: Text('English (US)'),
+                    leading: CircleAvatar(child: Icon(Icons.language),),
+                  ),
+                  ListTile(
+                    title: Text('Unit System'),
+                    subtitle: Text('Metric'),
+                    leading: CircleAvatar(child: Icon(Icons.straighten),),
+                    trailing: MenuAnchor(
+                      controller: MenuController(),
+                      menuChildren: <MenuItemButton>[
+                        MenuItemButton(
+                          child: Text('Metric (kg, ml)'),
+                          onPressed: () {},
+                        ),
+                        MenuItemButton(
+                          child: Text('Imperial (lb, oz)'),
+                          onPressed: () {},
+                        ),
+                      ],
+                      builder: (_, controller, _) {
+                        return IconButton(
+                          onPressed: () {
+                            controller.isOpen
+                            ? controller.close()
+                            : controller.open();
+                          }, 
+                          icon: controller.isOpen
+                            ? Icon(Icons.arrow_drop_up)
+                            : Icon(Icons.arrow_drop_down),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            )
+          ],
+        )
+      ),
+    );
+  }
+}

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -15,7 +15,7 @@ class SettingsView extends ConsumerWidget {
     return state.when(
       data: (data) => Scaffold(
         appBar: AppBar(
-          title: Text('Settings'),
+          title: Text('settings'.tr()),
         ),
         body: SafeArea(
           child: Center(

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,122 +1,130 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
+import 'package:hidroly/features/settings/ui/extensions/theme_mode_ui_extension.dart';
+import 'package:hidroly/features/settings/ui/view_model/settings_view_model.dart';
 
 class SettingsView extends ConsumerWidget {
   const SettingsView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Settings'),
-      ),
-      body: SafeArea(
-        minimum: EdgeInsets.all(16),
-        child: Column(
-          spacing: 6,
-          mainAxisAlignment: .center,
-          crossAxisAlignment: .start,
-          children: [
-            Center(
-              child: Column(
-                spacing: 4,
-                children: [
-                  Text(
-                    'Hidroly', 
-                    style: Theme.of(context).textTheme.headlineLarge!.copyWith(fontWeight: .bold),
-                    textAlign: .center,
-                  ),
-                  ElevatedButton.icon(
-                    onPressed: () {}, 
-                    label: Text('Buy me a coffee'),
-                    icon: Icon(Icons.favorite),
-                  ),
-                ],
-              ),
-            ),
-            
-            SizedBox(height: 24,),
+    final state = ref.watch(settingsViewModelProvider);
 
-            Card(
-              child: Column(
-                children: [
-                  ListTile(
-                    leading: CircleAvatar(child: Icon(Icons.style),),
-                    title: Text('Theme'),
-                    subtitle: Text('System'),
-                    trailing: MenuAnchor(
-                      controller: MenuController(),
-                      menuChildren: <MenuItemButton>[
-                        MenuItemButton(
-                          child: Text('System'),
-                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.system),
-                        ),
-                        MenuItemButton(
-                          child: Text('Light'),
-                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.light),
-                        ),
-                        MenuItemButton(
-                          child: Text('Dark'),
-                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.dark),
-                        ),
-                      ],
-                      builder: (_, controller, _) {
-                        return IconButton(
-                          onPressed: () {
-                            controller.isOpen
-                            ? controller.close()
-                            : controller.open();
-                          }, 
-                          icon: controller.isOpen
-                            ? Icon(Icons.arrow_drop_up)
-                            : Icon(Icons.arrow_drop_down),
-                        );
-                      },
+    return state.when(
+      data: (data) => Scaffold(
+        appBar: AppBar(
+          title: Text('Settings'),
+        ),
+        body: SafeArea(
+          minimum: EdgeInsets.all(16),
+          child: Column(
+            spacing: 6,
+            mainAxisAlignment: .center,
+            crossAxisAlignment: .start,
+            children: [
+              Center(
+                child: Column(
+                  spacing: 4,
+                  children: [
+                    Text(
+                      'Hidroly', 
+                      style: Theme.of(context).textTheme.headlineLarge!.copyWith(fontWeight: .bold),
+                      textAlign: .center,
                     ),
-                  ),
-                  ListTile(
-                    title: Text('Language'),
-                    subtitle: Text('English (US)'),
-                    leading: CircleAvatar(child: Icon(Icons.language),),
-                  ),
-                  ListTile(
-                    title: Text('Unit System'),
-                    subtitle: Text('Metric'),
-                    leading: CircleAvatar(child: Icon(Icons.straighten),),
-                    trailing: MenuAnchor(
-                      controller: MenuController(),
-                      menuChildren: <MenuItemButton>[
-                        MenuItemButton(
-                          child: Text('Metric (kg, ml)'),
-                          onPressed: () {},
-                        ),
-                        MenuItemButton(
-                          child: Text('Imperial (lb, oz)'),
-                          onPressed: () {},
-                        ),
-                      ],
-                      builder: (_, controller, _) {
-                        return IconButton(
-                          onPressed: () {
-                            controller.isOpen
-                            ? controller.close()
-                            : controller.open();
-                          }, 
-                          icon: controller.isOpen
-                            ? Icon(Icons.arrow_drop_up)
-                            : Icon(Icons.arrow_drop_down),
-                        );
-                      },
+                    ElevatedButton.icon(
+                      onPressed: () {}, 
+                      label: Text('Buy me a coffee'),
+                      icon: Icon(Icons.favorite),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            )
-          ],
-        )
-      ),
+              
+              SizedBox(height: 24,),
+
+              Card(
+                child: Column(
+                  children: [
+                    ListTile(
+                      leading: CircleAvatar(child: Icon(Icons.style),),
+                      title: Text('theme'.tr()),
+                      subtitle: Text(data.theme.label()),
+                      trailing: MenuAnchor(
+                        controller: MenuController(),
+                        menuChildren: <MenuItemButton>[
+                          MenuItemButton(
+                            child: Text('system'.tr()),
+                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.system),
+                          ),
+                          MenuItemButton(
+                            child: Text('light'.tr()),
+                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.light),
+                          ),
+                          MenuItemButton(
+                            child: Text('dark'.tr()),
+                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.dark),
+                          ),
+                        ],
+                        builder: (_, controller, _) {
+                          return IconButton(
+                            onPressed: () {
+                              controller.isOpen
+                              ? controller.close()
+                              : controller.open();
+                            }, 
+                            icon: controller.isOpen
+                              ? Icon(Icons.arrow_drop_up)
+                              : Icon(Icons.arrow_drop_down),
+                          );
+                        },
+                      ),
+                    ),
+                    ListTile(
+                      title: Text('Language'),
+                      subtitle: Text('English (US)'),
+                      leading: CircleAvatar(child: Icon(Icons.language),),
+                    ),
+                    ListTile(
+                      title: Text('Unit System'),
+                      subtitle: Text('Metric'),
+                      leading: CircleAvatar(child: Icon(Icons.straighten),),
+                      trailing: MenuAnchor(
+                        controller: MenuController(),
+                        menuChildren: <MenuItemButton>[
+                          MenuItemButton(
+                            child: Text('Metric (kg, ml)'),
+                            onPressed: () {},
+                          ),
+                          MenuItemButton(
+                            child: Text('Imperial (lb, oz)'),
+                            onPressed: () {},
+                          ),
+                        ],
+                        builder: (_, controller, _) {
+                          return IconButton(
+                            onPressed: () {
+                              controller.isOpen
+                              ? controller.close()
+                              : controller.open();
+                            }, 
+                            icon: controller.isOpen
+                              ? Icon(Icons.arrow_drop_up)
+                              : Icon(Icons.arrow_drop_down),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            ],
+          )
+        ),
+      ), 
+      error: (e, _) => Text('Error'), 
+      loading: () => Center(child: CircularProgressIndicator(),)
     );
   }
 }

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -20,108 +20,112 @@ class SettingsView extends ConsumerWidget {
           title: Text('Settings'),
         ),
         body: SafeArea(
-          minimum: EdgeInsets.all(16),
-          child: Column(
-            spacing: 6,
-            mainAxisAlignment: .center,
-            crossAxisAlignment: .start,
-            children: [
-              Center(
+          child: Center(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(12.0),
                 child: Column(
-                  spacing: 4,
+                  spacing: 6,
                   children: [
-                    Text(
-                      'Hidroly', 
-                      style: Theme.of(context).textTheme.headlineLarge!.copyWith(fontWeight: .bold),
-                      textAlign: .center,
+                    Center(
+                      child: Column(
+                        spacing: 4,
+                        children: [
+                          Text(
+                            'Hidroly', 
+                            style: Theme.of(context).textTheme.headlineLarge!.copyWith(fontWeight: .bold),
+                            textAlign: .center,
+                          ),
+                          ElevatedButton.icon(
+                            onPressed: () {}, 
+                            label: Text('Buy me a coffee'),
+                            icon: Icon(Icons.favorite),
+                          ),
+                        ],
+                      ),
                     ),
-                    ElevatedButton.icon(
-                      onPressed: () {}, 
-                      label: Text('Buy me a coffee'),
-                      icon: Icon(Icons.favorite),
-                    ),
+                    
+                    SizedBox(height: 24,),
+                
+                    Card(
+                      child: Column(
+                        children: [
+                          ListTile(
+                            leading: CircleAvatar(child: Icon(Icons.style),),
+                            title: Text('theme'.tr()),
+                            subtitle: Text(data.theme.label()),
+                            trailing: MenuAnchor(
+                              controller: MenuController(),
+                              menuChildren: <MenuItemButton>[
+                                MenuItemButton(
+                                  child: Text('system'.tr()),
+                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.system),
+                                ),
+                                MenuItemButton(
+                                  child: Text('light'.tr()),
+                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.light),
+                                ),
+                                MenuItemButton(
+                                  child: Text('dark'.tr()),
+                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.dark),
+                                ),
+                              ],
+                              builder: (_, controller, _) {
+                                return IconButton(
+                                  onPressed: () {
+                                    controller.isOpen
+                                    ? controller.close()
+                                    : controller.open();
+                                  }, 
+                                  icon: controller.isOpen
+                                    ? Icon(Icons.arrow_drop_up)
+                                    : Icon(Icons.arrow_drop_down),
+                                );
+                              },
+                            ),
+                          ),
+                          ListTile(
+                            title: Text('Language'),
+                            subtitle: Text('English (US)'),
+                            leading: CircleAvatar(child: Icon(Icons.language),),
+                          ),
+                          ListTile(
+                            title: Text('unitSystem'.tr()),
+                            subtitle: Text(data.unitSystem.label),
+                            leading: CircleAvatar(child: Icon(Icons.straighten),),
+                            trailing: MenuAnchor(
+                              controller: MenuController(),
+                              menuChildren: <MenuItemButton>[
+                                MenuItemButton(
+                                  child: Text('metric'.tr()),
+                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.metric),
+                                ),
+                                MenuItemButton(
+                                  child: Text('imperial'.tr()),
+                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.imperial),
+                                ),
+                              ],
+                              builder: (_, controller, _) {
+                                return IconButton(
+                                  onPressed: () {
+                                    controller.isOpen
+                                    ? controller.close()
+                                    : controller.open();
+                                  }, 
+                                  icon: controller.isOpen
+                                    ? Icon(Icons.arrow_drop_up)
+                                    : Icon(Icons.arrow_drop_down),
+                                );
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
                   ],
                 ),
               ),
-              
-              SizedBox(height: 24,),
-
-              Card(
-                child: Column(
-                  children: [
-                    ListTile(
-                      leading: CircleAvatar(child: Icon(Icons.style),),
-                      title: Text('theme'.tr()),
-                      subtitle: Text(data.theme.label()),
-                      trailing: MenuAnchor(
-                        controller: MenuController(),
-                        menuChildren: <MenuItemButton>[
-                          MenuItemButton(
-                            child: Text('system'.tr()),
-                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.system),
-                          ),
-                          MenuItemButton(
-                            child: Text('light'.tr()),
-                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.light),
-                          ),
-                          MenuItemButton(
-                            child: Text('dark'.tr()),
-                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.dark),
-                          ),
-                        ],
-                        builder: (_, controller, _) {
-                          return IconButton(
-                            onPressed: () {
-                              controller.isOpen
-                              ? controller.close()
-                              : controller.open();
-                            }, 
-                            icon: controller.isOpen
-                              ? Icon(Icons.arrow_drop_up)
-                              : Icon(Icons.arrow_drop_down),
-                          );
-                        },
-                      ),
-                    ),
-                    ListTile(
-                      title: Text('Language'),
-                      subtitle: Text('English (US)'),
-                      leading: CircleAvatar(child: Icon(Icons.language),),
-                    ),
-                    ListTile(
-                      title: Text('unitSystem'.tr()),
-                      subtitle: Text(data.unitSystem.label),
-                      leading: CircleAvatar(child: Icon(Icons.straighten),),
-                      trailing: MenuAnchor(
-                        controller: MenuController(),
-                        menuChildren: <MenuItemButton>[
-                          MenuItemButton(
-                            child: Text('metric'.tr()),
-                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.metric),
-                          ),
-                          MenuItemButton(
-                            child: Text('imperial'.tr()),
-                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.imperial),
-                          ),
-                        ],
-                        builder: (_, controller, _) {
-                          return IconButton(
-                            onPressed: () {
-                              controller.isOpen
-                              ? controller.close()
-                              : controller.open();
-                            }, 
-                            icon: controller.isOpen
-                              ? Icon(Icons.arrow_drop_up)
-                              : Icon(Icons.arrow_drop_down),
-                          );
-                        },
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            ],
+            ),
           )
         ),
       ), 

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
+import 'package:hidroly/core/providers/theme_provider.dart';
 
-class SettingsView extends StatelessWidget {
+class SettingsView extends ConsumerWidget {
   const SettingsView({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         title: Text('Settings'),
@@ -48,15 +51,15 @@ class SettingsView extends StatelessWidget {
                       menuChildren: <MenuItemButton>[
                         MenuItemButton(
                           child: Text('System'),
-                          onPressed: () {},
+                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.system),
                         ),
                         MenuItemButton(
                           child: Text('Light'),
-                          onPressed: () {},
+                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.light),
                         ),
                         MenuItemButton(
                           child: Text('Dark'),
-                          onPressed: () {},
+                          onPressed: () => ref.read(themeProviderProvider.notifier).setTheme(ThemeMode.dark),
                         ),
                       ],
                       builder: (_, controller, _) {

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -50,7 +50,7 @@ class SettingsView extends ConsumerWidget {
                                 );
                               }
                             }, 
-                            label: Text('BuyMeACoffee'.tr()),
+                            label: Text('buyMeACoffee'.tr()),
                             icon: Icon(Icons.favorite),
                           ),
                         ],

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,10 +1,6 @@
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hidroly/core/domain/enums/unit_systems.dart';
-import 'package:hidroly/core/providers/theme_provider.dart';
-import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
-import 'package:hidroly/features/settings/ui/extensions/theme_mode_ui_extension.dart';
+import 'package:hidroly/features/settings/ui/view/components/general_section.dart';
 import 'package:hidroly/features/settings/ui/view_model/settings_view_model.dart';
 
 class SettingsView extends ConsumerWidget {
@@ -47,81 +43,7 @@ class SettingsView extends ConsumerWidget {
                     
                     SizedBox(height: 24,),
                 
-                    Card(
-                      child: Column(
-                        children: [
-                          ListTile(
-                            leading: CircleAvatar(child: Icon(Icons.style),),
-                            title: Text('theme'.tr()),
-                            subtitle: Text(data.theme.label()),
-                            trailing: MenuAnchor(
-                              controller: MenuController(),
-                              menuChildren: <MenuItemButton>[
-                                MenuItemButton(
-                                  child: Text('system'.tr()),
-                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.system),
-                                ),
-                                MenuItemButton(
-                                  child: Text('light'.tr()),
-                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.light),
-                                ),
-                                MenuItemButton(
-                                  child: Text('dark'.tr()),
-                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setTheme(ThemeMode.dark),
-                                ),
-                              ],
-                              builder: (_, controller, _) {
-                                return IconButton(
-                                  onPressed: () {
-                                    controller.isOpen
-                                    ? controller.close()
-                                    : controller.open();
-                                  }, 
-                                  icon: controller.isOpen
-                                    ? Icon(Icons.arrow_drop_up)
-                                    : Icon(Icons.arrow_drop_down),
-                                );
-                              },
-                            ),
-                          ),
-                          ListTile(
-                            title: Text('Language'),
-                            subtitle: Text('English (US)'),
-                            leading: CircleAvatar(child: Icon(Icons.language),),
-                          ),
-                          ListTile(
-                            title: Text('unitSystem'.tr()),
-                            subtitle: Text(data.unitSystem.label),
-                            leading: CircleAvatar(child: Icon(Icons.straighten),),
-                            trailing: MenuAnchor(
-                              controller: MenuController(),
-                              menuChildren: <MenuItemButton>[
-                                MenuItemButton(
-                                  child: Text('metric'.tr()),
-                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.metric),
-                                ),
-                                MenuItemButton(
-                                  child: Text('imperial'.tr()),
-                                  onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.imperial),
-                                ),
-                              ],
-                              builder: (_, controller, _) {
-                                return IconButton(
-                                  onPressed: () {
-                                    controller.isOpen
-                                    ? controller.close()
-                                    : controller.open();
-                                  }, 
-                                  icon: controller.isOpen
-                                    ? Icon(Icons.arrow_drop_up)
-                                    : Icon(Icons.arrow_drop_down),
-                                );
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-                    )
+                    SettingsGeneralSection(data: data),
                   ],
                 ),
               ),

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,7 +1,9 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
+import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
 import 'package:hidroly/features/settings/ui/extensions/theme_mode_ui_extension.dart';
 import 'package:hidroly/features/settings/ui/view_model/settings_view_model.dart';
 
@@ -87,19 +89,19 @@ class SettingsView extends ConsumerWidget {
                       leading: CircleAvatar(child: Icon(Icons.language),),
                     ),
                     ListTile(
-                      title: Text('Unit System'),
-                      subtitle: Text('Metric'),
+                      title: Text('unitSystem'.tr()),
+                      subtitle: Text(data.unitSystem.label),
                       leading: CircleAvatar(child: Icon(Icons.straighten),),
                       trailing: MenuAnchor(
                         controller: MenuController(),
                         menuChildren: <MenuItemButton>[
                           MenuItemButton(
-                            child: Text('Metric (kg, ml)'),
-                            onPressed: () {},
+                            child: Text('metric'.tr()),
+                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.metric),
                           ),
                           MenuItemButton(
-                            child: Text('Imperial (lb, oz)'),
-                            onPressed: () {},
+                            child: Text('imperial'.tr()),
+                            onPressed: () => ref.read(settingsViewModelProvider.notifier).setUnitSystem(UnitSystem.imperial),
                           ),
                         ],
                         builder: (_, controller, _) {

--- a/lib/features/settings/ui/view/settings_view.dart
+++ b/lib/features/settings/ui/view/settings_view.dart
@@ -1,7 +1,9 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hidroly/features/settings/ui/view/components/general_section.dart';
 import 'package:hidroly/features/settings/ui/view_model/settings_view_model.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SettingsView extends ConsumerWidget {
   const SettingsView({super.key});
@@ -33,8 +35,22 @@ class SettingsView extends ConsumerWidget {
                             textAlign: .center,
                           ),
                           ElevatedButton.icon(
-                            onPressed: () {}, 
-                            label: Text('Buy me a coffee'),
+                            onPressed: () async {
+                              try {
+                                await launchUrl(Uri.parse('https://github.com/sponsors/om1cael'));
+                              } catch (_) {
+                                if(!context.mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text('errorOccurred'.tr(), textAlign: .center,),
+                                    behavior: .floating,
+                                    width: 250,
+                                    backgroundColor: Theme.of(context).colorScheme.primary,
+                                  ),
+                                );
+                              }
+                            }, 
+                            label: Text('BuyMeACoffee'.tr()),
                             icon: Icon(Icons.favorite),
                           ),
                         ],

--- a/lib/features/settings/ui/view_model/settings_view_model.dart
+++ b/lib/features/settings/ui/view_model/settings_view_model.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:hidroly/core/providers/theme_provider.dart';
+import 'package:hidroly/features/settings/ui/state/settings_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'settings_view_model.g.dart';
+
+@riverpod
+class SettingsViewModel extends _$SettingsViewModel {
+  @override
+  Future<SettingsState> build() async {
+    final themeMode = await ref.watch(themeProviderProvider.future);
+    
+    return SettingsState(
+      theme: themeMode,
+    );
+  }
+
+  void setTheme(ThemeMode theme) {
+    ref.read(themeProviderProvider.notifier).setTheme(theme);
+  }
+}

--- a/lib/features/settings/ui/view_model/settings_view_model.dart
+++ b/lib/features/settings/ui/view_model/settings_view_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
 import 'package:hidroly/core/providers/unit_system_provider.dart';

--- a/lib/features/settings/ui/view_model/settings_view_model.dart
+++ b/lib/features/settings/ui/view_model/settings_view_model.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
+import 'package:hidroly/core/providers/unit_system_provider.dart';
 import 'package:hidroly/features/settings/ui/state/settings_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,13 +13,19 @@ class SettingsViewModel extends _$SettingsViewModel {
   @override
   Future<SettingsState> build() async {
     final themeMode = await ref.watch(themeProviderProvider.future);
+    final unitSystem = await ref.watch(unitSystemProviderProvider.future);
     
     return SettingsState(
       theme: themeMode,
+      unitSystem: unitSystem,
     );
   }
 
   void setTheme(ThemeMode theme) {
     ref.read(themeProviderProvider.notifier).setTheme(theme);
+  }
+
+  void setUnitSystem(UnitSystem unitSystem) {
+    ref.read(unitSystemProviderProvider.notifier).setUnitSystem(unitSystem);
   }
 }

--- a/lib/features/settings/ui/view_model/settings_view_model.g.dart
+++ b/lib/features/settings/ui/view_model/settings_view_model.g.dart
@@ -33,7 +33,7 @@ final class SettingsViewModelProvider
   SettingsViewModel create() => SettingsViewModel();
 }
 
-String _$settingsViewModelHash() => r'53dba7b77c3270a35195d71bd9f4ce0b94e1010e';
+String _$settingsViewModelHash() => r'3ea480d94544a8e3505f35fbeaebb5e3a765e0e2';
 
 abstract class _$SettingsViewModel extends $AsyncNotifier<SettingsState> {
   FutureOr<SettingsState> build();

--- a/lib/features/settings/ui/view_model/settings_view_model.g.dart
+++ b/lib/features/settings/ui/view_model/settings_view_model.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settings_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SettingsViewModel)
+final settingsViewModelProvider = SettingsViewModelProvider._();
+
+final class SettingsViewModelProvider
+    extends $AsyncNotifierProvider<SettingsViewModel, SettingsState> {
+  SettingsViewModelProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settingsViewModelProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settingsViewModelHash();
+
+  @$internal
+  @override
+  SettingsViewModel create() => SettingsViewModel();
+}
+
+String _$settingsViewModelHash() => r'53dba7b77c3270a35195d71bd9f4ce0b94e1010e';
+
+abstract class _$SettingsViewModel extends $AsyncNotifier<SettingsState> {
+  FutureOr<SettingsState> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<SettingsState>, SettingsState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<SettingsState>, SettingsState>,
+              AsyncValue<SettingsState>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/summary/ui/view/summary_view.dart
+++ b/lib/features/summary/ui/view/summary_view.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hidroly/core/ui/extensions/unit_system_ui_extension.dart';
 import 'package:hidroly/features/summary/ui/enums/chart_selection.dart';
 import 'package:hidroly/features/summary/ui/view/components/summary_chart.dart';
@@ -23,7 +24,7 @@ class _SummaryViewState extends ConsumerState<SummaryView> {
         appBar: AppBar(
           title: Text('summary'.tr()),
           actions: [
-            IconButton(onPressed: () {}, icon: Icon(Icons.settings))
+            IconButton(onPressed: () => context.push('/settings'), icon: Icon(Icons.settings))
           ],
         ),
         body: SafeArea(

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -1,4 +1,3 @@
-import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/providers/unit_system_provider.dart';
 import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_daily_average_usecase.dart';

--- a/lib/features/summary/ui/view_model/summary_view_model.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
+import 'package:hidroly/core/providers/unit_system_provider.dart';
 import 'package:hidroly/features/hydration/domain/value_objects/water.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_daily_average_usecase.dart';
 import 'package:hidroly/features/summary/domain/usecases/get_monthly_chart_data_usecase.dart';
@@ -23,7 +24,7 @@ class SummaryViewModel extends _$SummaryViewModel {
     ).wait;
 
     final unitSystem = 
-      await ref.watch(settingsRepositoryProvider).readUnitSystem();
+      await ref.watch(unitSystemProviderProvider.future);
     
     final weeklyChartData = 
       await ref.read(getWeeklyChartDataUseCaseProvider).execute(unitSystem);

--- a/lib/features/summary/ui/view_model/summary_view_model.g.dart
+++ b/lib/features/summary/ui/view_model/summary_view_model.g.dart
@@ -33,7 +33,7 @@ final class SummaryViewModelProvider
   SummaryViewModel create() => SummaryViewModel();
 }
 
-String _$summaryViewModelHash() => r'5e3c0931f4099867833a4481accc58464f114095';
+String _$summaryViewModelHash() => r'6abe85094e35399aac20bc54247a8a0a99003807';
 
 abstract class _$SummaryViewModel extends $AsyncNotifier<SummaryState> {
   FutureOr<SummaryState> build();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,7 @@ class MainApp extends ConsumerWidget {
     final themeState = ref.watch(themeProviderProvider);
     
     return themeState.when(
-        data: (theme) => MaterialApp.router(
+      data: (theme) => MaterialApp.router(
         localizationsDelegates: context.localizationDelegates,
         supportedLocales: context.supportedLocales,
         locale: context.locale,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/navigation/app_routes.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
 import 'package:hidroly/core/ui/themes/themes.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/data/repositories/settings_repository_impl.dart';
 import 'package:hidroly/core/navigation/app_routes.dart';
+import 'package:hidroly/core/providers/theme_provider.dart';
 import 'package:hidroly/core/ui/themes/themes.dart';
 
 Future<void> main() async {
@@ -25,13 +27,20 @@ class MainApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return MaterialApp.router(
-      localizationsDelegates: context.localizationDelegates,
-      supportedLocales: context.supportedLocales,
-      locale: context.locale,
-      theme: Themes.lightTheme,
-      darkTheme: Themes.darkTheme,
-      routerConfig: ref.watch(routerProvider),
+    final themeState = ref.watch(themeProviderProvider);
+    
+    return themeState.when(
+        data: (theme) => MaterialApp.router(
+        localizationsDelegates: context.localizationDelegates,
+        supportedLocales: context.supportedLocales,
+        locale: context.locale,
+        theme: Themes.lightTheme,
+        darkTheme: Themes.darkTheme,
+        themeMode: theme,
+        routerConfig: ref.watch(routerProvider),
+      ),
+      error: (e, _) => const Center(child: Text('A fatal error happened.'),), 
+      loading: () => const Center(child: CircularProgressIndicator(),),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -938,6 +938,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   riverpod_annotation: ^4.0.2
   shared_preferences: ^2.5.4
   shared_preferences_platform_interface: ^2.4.2
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Description
This PR introduces the core infrastructure for the settings.

While the settings module is incremental (notifications and manual goals will be added in upcoming PRs), the technical foundation for saving and reading user preferences is now fully operational.

### Key Changes:
* **Persistent Theme:** Implemented ThemeMode switching (Light/Dark/System) persisted via `SharedPreferences`.
* **Unit System:** Initial support for unit system toggling (Metric/Imperial) across the app.
* **Reactive State:** Fully integrated `Riverpod` with code generation to ensure UI updates instantly upon preference changes.
* **Localization:** Added translation keys for all settings labels and descriptions.
* **External Links:** Integrated `url_launcher` for the "Buy me a coffee" donation button.

### Next Steps:
- [ ] Implement daily goal update based on user metrics.
- [ ] Add the manual/custom goal override feature.

### 📦 Dependencies Added:
- `url_launcher`: For handling external donation links.