### PR TITLE
ci: only run merge sentinel on pull request

### DIFF
--- a/.github/workflows/merge_sentinel.yaml
+++ b/.github/workflows/merge_sentinel.yaml
@@ -3,6 +3,12 @@ name: Merge Sentinel
 on:
   pull_request:
     branches: [main, v2-rewrite]
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'testing/**'
+      - 'android/**'
+      - '.github/workflows/**'
 
 jobs:
   guard:

--- a/.github/workflows/merge_sentinel.yaml
+++ b/.github/workflows/merge_sentinel.yaml
@@ -3,11 +3,10 @@ name: Merge Sentinel
 on:
   pull_request:
     branches: [main, v2-rewrite]
-  push:
-    branches: [main, v2-rewrite]
 
 jobs:
-  test:
+  guard:
+    name: Guard
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge_sentinel.yaml
+++ b/.github/workflows/merge_sentinel.yaml
@@ -8,6 +8,8 @@ on:
       - 'test/**'
       - 'testing/**'
       - 'android/**'
+      - 'pubspec.lock'
+      - 'pubspec.yaml'
       - '.github/workflows/**'
 
 jobs:


### PR DESCRIPTION
# Description
This PR prevents Merge Sentinel from running after the pull is merged and sets specific paths for it to be run.