### PR TITLE
feat: add notification quick actions

### DIFF
--- a/lib/core/data/repositories/day_repository_impl.dart
+++ b/lib/core/data/repositories/day_repository_impl.dart
@@ -49,6 +49,17 @@ class DayRepositoryImpl implements DayRepository {
   }
 
   @override
+  Future<Day> readLatest() async {
+    final dayTableData = await (_database
+      .select(_database.dayTable)
+      ..orderBy([(u) => OrderingTerm(expression: u.id, mode: .desc)])
+      ..limit(1))
+      .getSingle();
+    
+    return dayTableData.toEntity();
+  }
+
+  @override
   Future<List<Day>> readByRange(DateTime start, DateTime end) async {
     final dayTableDataList = await (_database
       .select(_database.dayTable)

--- a/lib/core/domain/interfaces/notification_service.dart
+++ b/lib/core/domain/interfaces/notification_service.dart
@@ -1,5 +1,7 @@
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
+
 abstract class NotificationService {
   Future<void> initialize();
-  Future<void> showNotification();
+  Future<void> showNotification(UnitSystem unitSystem);
   void askForPermission();
 }

--- a/lib/core/domain/repositories/day_repository.dart
+++ b/lib/core/domain/repositories/day_repository.dart
@@ -4,6 +4,7 @@ abstract class DayRepository {
   Future<int> save(Day day);
   Future<Day> read(int id);
   Future<List<Day>> readAll();
+  Future<Day> readLatest();
   Future<List<Day>> readByRange(DateTime start, DateTime end);
   Future<Day> readOrCreateByDate(DateTime date);
 }

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -1,9 +1,24 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hidroly/core/domain/interfaces/notification_service.dart';
+import 'package:hidroly/features/hydration/data/repositories/hydration_repository_impl.dart';
 
 @pragma('vm:entry-point')
-void notificationActionTapResponse(NotificationResponse notificationResponse) {
-  // TODO: Handle actions
+void notificationActionTapResponse(NotificationResponse notificationResponse) async {
+  final providerContainer = ProviderContainer();
+
+  final cupMap = {
+    'water_standard': 200,
+    'water_medium': 300,
+    'water_bottle': 500,
+  };
+
+  final cup = cupMap[notificationResponse.actionId];
+
+  if(cup != null) {
+    await providerContainer.read(hydrationRepositoryProvider)
+      .addWater(1, cup);
+  }
 }
 
 class LocalNotificationService implements NotificationService {
@@ -34,6 +49,11 @@ class LocalNotificationService implements NotificationService {
         channelDescription: 'Receive reminders to drink water',
         importance: .high,
         priority: .high,
+        actions: <AndroidNotificationAction>[
+          AndroidNotificationAction('water_standard', '200 ml'),
+          AndroidNotificationAction('water_medium', '300 ml'),
+          AndroidNotificationAction('water_bottle', '500 ml'),
+        ],
       );
     
     final notificationDetails =

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -59,7 +59,7 @@ class LocalNotificationService implements NotificationService {
         priority: .high,
         actions: <AndroidNotificationAction>[
           AndroidNotificationAction('water_standard', unitSystem == .metric ? '200 ml' : '7 oz'),
-          AndroidNotificationAction('water_medium', unitSystem == .metric ? '350 ml' : '12 oz'),
+          AndroidNotificationAction('water_medium', unitSystem == .metric ? '300 ml' : '10 oz'),
           AndroidNotificationAction('water_bottle', unitSystem == .metric ? '500 ml' : '17 oz'),
         ],
       );

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -19,6 +19,8 @@ void notificationActionTapResponse(NotificationResponse notificationResponse) as
     await providerContainer.read(hydrationRepositoryProvider)
       .addWater(1, cup);
   }
+
+  providerContainer.dispose();
 }
 
 class LocalNotificationService implements NotificationService {

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -50,6 +50,8 @@ class LocalNotificationService implements NotificationService {
 
   @override
   Future<void> showNotification(UnitSystem unitSystem) async {
+    await flutterLocalNotificationsPlugin.cancelAll();
+
     final androidNotificationDetails =
       AndroidNotificationDetails(
         'h_reminder', 

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/domain/interfaces/notification_service.dart';
 import 'package:hidroly/features/hydration/data/repositories/hydration_repository_impl.dart';
 
@@ -48,7 +49,7 @@ class LocalNotificationService implements NotificationService {
   }
 
   @override
-  Future<void> showNotification() async {
+  Future<void> showNotification(UnitSystem unitSystem) async {
     final androidNotificationDetails =
       AndroidNotificationDetails(
         'h_reminder', 
@@ -57,9 +58,9 @@ class LocalNotificationService implements NotificationService {
         importance: .high,
         priority: .high,
         actions: <AndroidNotificationAction>[
-          AndroidNotificationAction('water_standard', '200 ml'),
-          AndroidNotificationAction('water_medium', '300 ml'),
-          AndroidNotificationAction('water_bottle', '500 ml'),
+          AndroidNotificationAction('water_standard', unitSystem == .metric ? '200 ml' : '7 oz'),
+          AndroidNotificationAction('water_medium', unitSystem == .metric ? '350 ml' : '12 oz'),
+          AndroidNotificationAction('water_bottle', unitSystem == .metric ? '500 ml' : '17 oz'),
         ],
       );
     

--- a/lib/infra/notifications/local_notification_service.dart
+++ b/lib/infra/notifications/local_notification_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/data/repositories/day_repository_impl.dart';
 import 'package:hidroly/core/domain/interfaces/notification_service.dart';
 import 'package:hidroly/features/hydration/data/repositories/hydration_repository_impl.dart';
 
@@ -16,8 +17,12 @@ void notificationActionTapResponse(NotificationResponse notificationResponse) as
   final cup = cupMap[notificationResponse.actionId];
 
   if(cup != null) {
+    final latestDay = await providerContainer
+      .read(dayRepositoryProvider)
+      .readLatest();
+
     await providerContainer.read(hydrationRepositoryProvider)
-      .addWater(1, cup);
+      .addWater(latestDay.id, cup);
   }
 
   providerContainer.dispose();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hidroly/core/domain/enums/unit_systems.dart';
 import 'package:hidroly/core/navigation/app_routes.dart';
 import 'package:hidroly/core/providers/theme_provider.dart';
 import 'package:hidroly/core/ui/themes/themes.dart';
@@ -13,7 +14,7 @@ Future<void> main() async {
   await LocalNotificationService().initialize();
 
   // TODO: Don't call showNotification on main
-  await LocalNotificationService().showNotification();
+  await LocalNotificationService().showNotification(UnitSystem.metric);
 
   runApp(
     EasyLocalization(

--- a/test/core/data/repositories/day_repository_impl_test.dart
+++ b/test/core/data/repositories/day_repository_impl_test.dart
@@ -64,5 +64,24 @@ void main() {
       expect(day, isNotNull);
       expect(queryDay.id, equals(day.id));
     });
+
+    test('Should get more recent day on readLatest', () async {
+      final latestDayDailyGoal = 2500;
+
+      await provider
+        .read(dayRepositoryProvider)
+        .save(Day(dailyGoal: Water.ml(3000), createdAt: DateTime(2026, 1, 1)));
+      
+      await provider
+        .read(dayRepositoryProvider)
+        .save(Day(dailyGoal: Water.ml(latestDayDailyGoal), createdAt: DateTime(2026, 1, 2)));
+      
+      final latestDay = await provider
+        .read(dayRepositoryProvider)
+        .readLatest();
+      
+      expect(latestDay.id, 2);
+      expect(latestDay.dailyGoal.ml, latestDayDailyGoal);
+    });
   });
 }


### PR DESCRIPTION
### Description
This PR implements the core background hydration logic. It enables users to log water intake directly through notification action buttons without opening the app. This involved setting up background isolates, manual Riverpod dependency injection via `ProviderContainer`, and enhancing the repository layer with unit-tested logic.

### Key Changes:
- **Background Actions:** Added notification actions (`water_standard`, `water_medium`, `water_bottle`) for quick logging.
- **Background Isolate:** Implemented to handle interaction responses even when the app is in a terminated state.
- **ProviderContainer Management:** Integrated Riverpod's `ProviderContainer` for background dependency injection.
- **Repository Enhancements:** - Implemented `readLatest()` in `DayRepository` to fetch the most recent daily entry.
- **Unit Testing:** Added test for `DayRepository's` `readLatest` to ensure correct data retrieval and sorting logic.
- **Unit Systems:** Added dynamic labeling for **Metric** and **Imperial** systems (200ml/7oz, 300ml/10oz, 500ml/17oz).
- **Notification Management:** Added a cleanup step to cancel pending notifications before triggering new schedules to prevent tray clutter.