### PR TITLE
build: remove build id with gradle task

### DIFF
--- a/.github/workflows/d_man.yaml
+++ b/.github/workflows/d_man.yaml
@@ -43,17 +43,6 @@ jobs:
       - name: Install Dependencies
         run: flutter pub get
       
-      - name: Patch dartjni
-        run: |
-          JNI_CMAKE=$(find $HOME/.pub-cache/hosted/pub.dev -path "*/jni-*/src/CMakeLists.txt" | head -n 1)
-          if [ -n "$JNI_CMAKE" ] && [ -f "$JNI_CMAKE" ]; then
-            sed -i '2i add_link_options("LINKER:--build-id=none")' "$JNI_CMAKE"
-            echo "Patched CMakeLists.txt in $JNI_CMAKE"
-          else
-            echo "Error: jni CMakeLists.txt not found in expected location."
-            exit 1
-          fi
-      
       - name: Generate Code
         run: dart run build_runner build --delete-conflicting-outputs
       

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -135,3 +135,7 @@ android.applicationVariants.configureEach {
         }
     }
 }
+
+afterEvaluate {
+    apply(from = "../no-build-id.gradle")
+}

--- a/android/no-build-id.gradle
+++ b/android/no-build-id.gradle
@@ -1,0 +1,40 @@
+// MIT License - Copyright (c) 2026 Simple Badminton Contributors
+
+def home = System.getenv("ANDROID_HOME") ?: ""
+println "[no-build-id] ANDROID_HOME environment variable value: ${home}"
+def objcopy = null
+if (home) {
+    def ndkRoot = new File("${home}/ndk")
+    if (ndkRoot.isDirectory()) {
+        ndkRoot.eachDir { ver ->
+            if (objcopy) return
+            println "[no-build-id] first path to check for llvm-objcopy: ${ver}/toolchains/llvm/prebuilt"
+            def prebuilt = new File("${ver}/toolchains/llvm/prebuilt")
+            if (!prebuilt.isDirectory()) return
+            prebuilt.eachDir { platform ->
+                if (objcopy) return
+                println "[no-build-id] second path to check for llvm-objcopy: ${platform}/bin/llvm-objcopy"
+                def c = new File("${platform}/bin/llvm-objcopy")
+                if (c.exists()) objcopy = c.absolutePath
+            }
+        }
+    }
+}
+if (!objcopy) {
+    println "[no-build-id] llvm-objcopy not found - Build ID strip skipped"
+    return
+}
+final String oc = objcopy
+tasks.matching { it.name.startsWith("merge") && it.name.endsWith("NativeLibs") }
+    .configureEach { t ->
+        t.doLast {
+            t.outputs.files.each { dir ->
+                if (!(dir instanceof File) || !dir.isDirectory()) return
+                dir.eachFileRecurse { f ->
+                    if (!f.name.endsWith('.so')) return
+                    exec { commandLine oc, '--remove-section', '.note.gnu.build-id', f.absolutePath }
+                    println "[no-build-id] stripped Build ID: ${f.name}"
+                }
+            }
+        }
+    }


### PR DESCRIPTION
This PR fixes #174 by removing the build id with a gradle task, rather than fixing it with d_man.