### PR TITLE
fix: migration running even if user already did it

### DIFF
--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -22,7 +22,7 @@ GoRouter router(Ref ref) {
       final isMigrationNeeded = await ref.read(migrationRepositoryProvider).getOldDatabase() != null;
       final setupCompleted = dayList.isNotEmpty;
 
-      if(isMigrationNeeded) {        
+      if(isMigrationNeeded) {
         if(state.matchedLocation != '/migration') {
           return '/migration';
         }

--- a/lib/features/migration/data/repositories/migration_repository_impl.dart
+++ b/lib/features/migration/data/repositories/migration_repository_impl.dart
@@ -119,7 +119,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
       });
 
       await migrateNotificationSetup();
-      return;
     }
 
     await markDatabaseAsBackup();

--- a/lib/features/migration/data/repositories/migration_repository_impl.dart
+++ b/lib/features/migration/data/repositories/migration_repository_impl.dart
@@ -51,71 +51,77 @@ class MigrationRepositoryImpl implements MigrationRepository {
     final queryExecutor = tempExecutor;
     queryExecutor.ensureOpen(_FakeUser());
 
-    await _appDatabase.transaction(() async {
-      final days = await queryExecutor.runSelect('SELECT * FROM days ORDER BY id DESC', []);
-      await _appDatabase.batch((batch) {
-        for(final day in days) {
-          final date = day['date'] as String;
-          DateTime? dateTime = DateTime.tryParse(date);
-          if(dateTime == null) continue;
+    final dayCount = await _appDatabase.dayTable.count().getSingle();
 
-          final normalizedDateTime = DateTime(dateTime.year, dateTime.month, dateTime.day);
-
-          batch.insert(
-            _appDatabase.dayTable, 
-            DayTableCompanion.insert(
-              id: Value(day['id'] as int),
-              dailyGoal: day['dailyGoal'] as int,
-              currentAmount: Value(day['currentAmount'] as int),
-              createdAt: normalizedDateTime,
-            ),
-            mode: .insertOrIgnore,
-          );
-        }
-      });
-
-      final cups = await queryExecutor.runSelect('SELECT * FROM custom_cups', []);
-      await _appDatabase.batch((batch) {
-        for(final cup in cups) {
-          batch.insert(
-            _appDatabase.cupsTable,
-            CupsTableCompanion.insert(
-              id: Value(cup['id'] as int),
-              amount: cup['amount'] as int,
-            ),
-          );
-        }
-      });
-
-      final history = await queryExecutor.runSelect('SELECT * FROM daily_history', []);
+    if(dayCount == 0) {
+      await _appDatabase.transaction(() async {
+        final days = await queryExecutor.runSelect('SELECT * FROM days ORDER BY id DESC', []);
+        await _appDatabase.batch((batch) {
+          for(final day in days) {
+            final date = day['date'] as String;
+            DateTime? dateTime = DateTime.tryParse(date);
+            if(dateTime == null) continue;
       
-      final dayList = await _appDatabase.select(_appDatabase.dayTable).get();
-      final validDayIds = dayList.map((day) => day.id).toSet();
-
-      await _appDatabase.batch((batch) {
-        for(final historyItem in history) {
-          final date = historyItem['dateTime'] as String;
-          DateTime dateTime = DateTime.parse(date);
-
-          final dayId = historyItem['dayId'] as int;
-
-          if(validDayIds.contains(dayId)) {
+            final normalizedDateTime = DateTime(dateTime.year, dateTime.month, dateTime.day);
+      
             batch.insert(
-              _appDatabase.historyItemsTable,
-              HistoryItemsTableCompanion.insert(
-                id: Value(historyItem['id'] as int),
-                day: dayId, 
-                amount: historyItem['amount'] as int,
-                createdAt: Value(dateTime),
+              _appDatabase.dayTable, 
+              DayTableCompanion.insert(
+                id: Value(day['id'] as int),
+                dailyGoal: day['dailyGoal'] as int,
+                currentAmount: Value(day['currentAmount'] as int),
+                createdAt: normalizedDateTime,
               ),
               mode: .insertOrIgnore,
             );
           }
-        }
+        });
+      
+        final cups = await queryExecutor.runSelect('SELECT * FROM custom_cups', []);
+        await _appDatabase.batch((batch) {
+          for(final cup in cups) {
+            batch.insert(
+              _appDatabase.cupsTable,
+              CupsTableCompanion.insert(
+                id: Value(cup['id'] as int),
+                amount: cup['amount'] as int,
+              ),
+            );
+          }
+        });
+      
+        final history = await queryExecutor.runSelect('SELECT * FROM daily_history', []);
+        
+        final dayList = await _appDatabase.select(_appDatabase.dayTable).get();
+        final validDayIds = dayList.map((day) => day.id).toSet();
+      
+        await _appDatabase.batch((batch) {
+          for(final historyItem in history) {
+            final date = historyItem['dateTime'] as String;
+            DateTime dateTime = DateTime.parse(date);
+      
+            final dayId = historyItem['dayId'] as int;
+      
+            if(validDayIds.contains(dayId)) {
+              batch.insert(
+                _appDatabase.historyItemsTable,
+                HistoryItemsTableCompanion.insert(
+                  id: Value(historyItem['id'] as int),
+                  day: dayId, 
+                  amount: historyItem['amount'] as int,
+                  createdAt: Value(dateTime),
+                ),
+                mode: .insertOrIgnore,
+              );
+            }
+          }
+        });
       });
-    });
 
-    await migrateNotificationSetup();
+      await migrateNotificationSetup();
+      return;
+    }
+
     await markDatabaseAsBackup();
   }
 

--- a/test/features/migration/data/repositories/migration_repository_impl_test.dart
+++ b/test/features/migration/data/repositories/migration_repository_impl_test.dart
@@ -15,6 +15,15 @@ import 'package:shared_preferences_platform_interface/shared_preferences_async_p
 import '../../../../../testing/fake_sql_user.dart';
 import '../../../../../testing/infra/mock_notification_service.dart';
 
+class MigrationRepositoryImplSpy extends MigrationRepositoryImpl {
+  MigrationRepositoryImplSpy(super.appDatabase, super.settingsRepository, super.notificationService, super.translationProvider);
+
+  @override
+  Future<void> markDatabaseAsBackup() async {
+    return;
+  }
+}
+
 void main() {
   late MigrationRepositoryImpl repository;
   late SettingsRepository settingsRepository;
@@ -42,7 +51,7 @@ void main() {
     final notificationService = container.read(localNotificationServiceProvider);
     final translationProvider = container.read(translationProviderProvider);
 
-    repository = MigrationRepositoryImpl(appDatabase, settingsRepository, notificationService, translationProvider);
+    repository = MigrationRepositoryImplSpy(appDatabase, settingsRepository, notificationService, translationProvider);
   });
 
   tearDown(() async {


### PR DESCRIPTION
## Description
This PR should fix issue #198, where the app is trying to migrate even though it already did previously.

## Fix
The app still shows the migration page, but it doesn't run any migration code, and instead sets the old database as backup and ignores it forever.